### PR TITLE
fix: Allow request dto to be accessible in the process response script

### DIFF
--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,0 +1,2 @@
+### Fix
+- Allow Process Response Script to access request dto

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -161,6 +161,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             {
                 using var engine = new Jint.Engine()
                     .SetValue("log", new Action<object>(o => context.Log.Log(LogLevel.Debug, $"User Script log: {o}" )))
+                    .SetValue("request", request)
                     .SetValue("response", responseDto)
                     .Execute(queryParameters.ProcessResponseScript);
 
@@ -325,6 +326,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
                 using var responseEngine = new Jint.Engine()
                     .SetValue("log", new Action<object>(o => context.Log.Log(LogLevel.Debug, $"User Script log: {o}")))
+                    .SetValue("request", request)
                     .SetValue("response", responseDto)
                     .Execute(queryParametersTestConnection.ProcessResponseScript);
 
@@ -373,7 +375,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 {
                     var key = en.Current.Key;
                     key = SanitizeVocabularyKey(key); //TODO Maybe the key can be sanitized in the end of ExecuteSearch(), but the Dictionary results need to be updated
-                    metadata.Properties[key] = en.Current.Value.ToString();
+                    metadata.Properties[key] = en.Current.Value?.ToString();
                 }
             }
         }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#53477](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/53477)

vocabulary key and properties value can now be read from `request` object in process response script
<img width="1914" height="940" alt="image" src="https://github.com/user-attachments/assets/72d5760e-5165-4be9-b29a-f828b3c1d925" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local
