### PR TITLE
fix: Keep original request dto and make it accessible in process response script

### DIFF
--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -109,7 +109,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             queryParameters.Url = ReplaceTokens(queryParameters.Url, queryParameters);
 
-            var request = new RequestDto
+            // keep the original request and make it accessible in process response script
+            var originalRequest = new RequestDto
             {
                 Method = queryParameters.Method,
                 Url = queryParameters.Url,
@@ -120,6 +121,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     Properties = JsonConvert.DeserializeObject<List<PropertyDto>>(queryParameters.Body ?? string.Empty)
                 }
             };
+
+            var request = originalRequest;
 
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessRequestScript))
             {
@@ -162,6 +165,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 using var engine = new Jint.Engine()
                     .SetValue("log", new Action<object>(o => context.Log.Log(LogLevel.Information, $"User Script log: {o}" )))
                     .SetValue("request", request)
+                    .SetValue("originalRequest", originalRequest)
                     .SetValue("response", responseDto)
                     .Execute(queryParameters.ProcessResponseScript);
 


### PR DESCRIPTION

<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#53477](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/53477)

Similar release note created before, will skip the release note in this pr

## How has it been tested? <!-- Remove if not needed -->
Manually in local

