### PR TITLE
feat: Introduce the new edit script control

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -1,5 +1,6 @@
 ### Features
 - Added exception messages along the external search pipeline to improve clarity and logging
+- Introduced the new Edit Script control
 
 ### Chores
 - Standardized "URL" capitalization across the project

--- a/docs/4.7.0-release-notes.md
+++ b/docs/4.7.0-release-notes.md
@@ -1,4 +1,5 @@
 ### Features
+- Introduced the new Edit Script control
 
 ### Chores
 - Standardized "URL" capitalization across the project

--- a/src/ExternalSearch.Providers.RestApi/Constants.cs
+++ b/src/ExternalSearch.Providers.RestApi/Constants.cs
@@ -136,7 +136,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             new()
             {
                 DisplayName = "Process Request Script",
-                Type = "multiline",
+                Type = "scriptEditor",
                 IsRequired = false,
                 Name = KeyName.ProcessRequestScript,
                 Help = "The JavaScript script that will be used to process the request to external source.",
@@ -145,7 +145,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             new()
             {
                 DisplayName = "Process Response Script",
-                Type = "multiline",
+                Type = "scriptEditor",
                 IsRequired = false,
                 Name = KeyName.ProcessResponseScript,
                 Help = "The JavaScript script that will be used to process the response from external source.",


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#54471](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/54471)

The new Scripts screen provide better UX for users to type in the REST API scripts, larger text input area, different text color and with intellisense
![RESTAPIEnricherrScriptsScreen](https://github.com/user-attachments/assets/77fff285-293c-4514-98be-00a6a8c5094c)

## How has it been tested? <!-- Remove if not needed -->
Manually in local

