### PR TITLE
fix: Retry ExecuteSearch if TooManyRequests

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -2,5 +2,8 @@
 - Added exception messages along the external search pipeline to improve clarity and logging
 - Introduced the new Edit Script control
 
-### Chores
+### Fix
+- Retry ExecuteSearch if TooManyRequests
+
+### Chore
 - Standardized "URL" capitalization across the project

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -101,6 +101,15 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
         public IEnumerable<IExternalSearchQueryResult> ExecuteSearch(ExecutionContext context, IExternalSearchQuery query, IDictionary<string, object> config, IProvider provider)
         {
+            return ActionExtensions.ExecuteWithRetry(
+                () => InternalExecuteSearch(context, query).ToArray(), // important we need to materialize the enumerable for ExecuteWithRetry to work
+                retryCount: 1000,
+                isTransient: ex => ex.ToString().Contains("TooManyRequests")
+            );
+        }
+
+        private IEnumerable<IExternalSearchQueryResult> InternalExecuteSearch(ExecutionContext context, IExternalSearchQuery query)
+        {
             var queryParameters = GetQueryParameters(query);
 
             if (string.IsNullOrEmpty(queryParameters.Url))
@@ -200,7 +209,6 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             var results = JsonConvert.DeserializeObject<ResultsDto[]>(responseDto.Content);
 
             yield return new ExternalSearchQueryResult<ResultsDto[]>(query, results);
-
         }
 
         public IEnumerable<Clue> BuildClues(ExecutionContext context, IExternalSearchQuery query, IExternalSearchQueryResult result, IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#54524](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/54524)

After adding the retry, enriching 100 golden records produce the following result: (69 records got enriched, 31 got empty content) 
<img width="1909" height="944" alt="image" src="https://github.com/user-attachments/assets/42077493-732d-4d5a-9eef-08b7ad61f659" />

<img width="1914" height="943" alt="image" src="https://github.com/user-attachments/assets/d36788c1-183b-4a18-a52e-8396316aba7c" />


## How has it been tested? <!-- Remove if not needed -->
Manually in local

