### PR TITLE
fix: Ability to add or remove confidence score from results for V1 Enricher

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -4,7 +4,7 @@
 
 ### Fix
 - Retry ExecuteSearch if TooManyRequests
-- Added a control to decide if _cluedin_confidenceScore need to be included in results
+- Added a control to decide if _cluedin_confidenceScore need to be included in results for V1 Enricher
 
 ### Chore
 - Standardized "URL" capitalization across the project

--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -4,6 +4,7 @@
 
 ### Fix
 - Retry ExecuteSearch if TooManyRequests
+- Added a control to decide if _cluedin_confidenceScore need to be included in results
 
 ### Chore
 - Standardized "URL" capitalization across the project

--- a/src/ExternalSearch.Providers.RestApi/Constants.cs
+++ b/src/ExternalSearch.Providers.RestApi/Constants.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using CluedIn.Core.Data.Relational;
+using CluedIn.Core.ExternalSearch;
 using CluedIn.Core.Providers;
 
 namespace CluedIn.ExternalSearch.Providers.RestApi
@@ -48,6 +49,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
         public struct KeyName
         {
             public const string AcceptedEntityType = "acceptedEntityType";
+            public const string IncludeConfidenceScore = "includeConfidenceScore";
             public const string Method = "method";
             public const string Url = "url";
             public const string ApiKey = "apiKey";
@@ -150,6 +152,24 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 Name = KeyName.ProcessResponseScript,
                 Help = "The JavaScript script that will be used to process the response from external source.",
                 Options = new Dictionary<string, object>() {{"Scripting Language", "JavaScript"}}
+            },
+            new()
+            {
+                DisplayName = "Include Confidence Score",
+                Type = "checkbox",
+                IsRequired = false,
+                Name = KeyName.IncludeConfidenceScore,
+                Help = "When enabled, the results will include a confidence score, which can be used during data processing.",
+                DisplayDependencies =
+                [
+                    new ControlDisplayDependency
+                    {
+                        Name = ExternalSearchConstants.EnricherV2SendToLandingZone,
+                        Operator = ControlDependencyOperator.NotEquals,
+                        Value = "true",
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    },
+                ]
             },
         };
 

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchJobData.cs
@@ -15,6 +15,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             Headers = GetValue<string>(configuration, Constants.KeyName.Headers);
             ProcessRequestScript = GetValue<string>(configuration, Constants.KeyName.ProcessRequestScript);
             ProcessResponseScript = GetValue<string>(configuration, Constants.KeyName.ProcessResponseScript);
+            IncludeConfidenceScore = GetValue<bool>(configuration, Constants.KeyName.IncludeConfidenceScore);
         }
 
         public IDictionary<string, object> ToDictionary()
@@ -28,6 +29,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 { Constants.KeyName.ApiKey, ApiKey },
                 { Constants.KeyName.ProcessRequestScript, ProcessRequestScript },
                 { Constants.KeyName.ProcessResponseScript, ProcessResponseScript },
+                { Constants.KeyName.IncludeConfidenceScore, IncludeConfidenceScore }
             };
         }
 
@@ -39,5 +41,6 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
         public string Headers { get; set; }
         public string ProcessRequestScript { get; set; }
         public string ProcessResponseScript { get; set; }
+        public bool IncludeConfidenceScore { get; set; }
     }
 }

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
-using System.Web;
 using Castle.MicroKernel.Registration;
 using CluedIn.ExternalSearch.Providers.RestApi.Vocabularies;
 using Microsoft.Extensions.Logging;
@@ -221,7 +220,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                         .ToDeterministicGuid());
                 var clue = new Clue(code, context.Organization);
 
-                PopulateMetadata(clue.Data.EntityData, resultItem, request);
+                PopulateMetadata(clue.Data.EntityData, resultItem, request, config);
 
                 var logoKey = clue.Data.EntityData.Properties?.Keys.FirstOrDefault(key => key.Contains(".logo"));
                 if (!string.IsNullOrEmpty(logoKey) && clue.Data.EntityData.Properties.TryGetValue(logoKey, out var property))
@@ -240,7 +239,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             using (context.Log.BeginScope("{0} {1}: request {2}, result {3}", GetType().Name, "GetPrimaryEntityMetadata",
                        request, result))
             {
-                var metadata = CreateMetadata(result.As<ResultsDto[]>(), request);
+                var metadata = CreateMetadata(result.As<ResultsDto[]>(), request, config);
 
                 context.Log.LogInformation(
                     "Primary entity meta data created, Name: '{Name}' OriginEntityCode: '{OriginEntityCode}'",
@@ -368,17 +367,16 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             }
         }
 
-        private IEntityMetadata CreateMetadata(IExternalSearchQueryResult<ResultsDto[]> resultItem, IExternalSearchRequest request)
+        private IEntityMetadata CreateMetadata(IExternalSearchQueryResult<ResultsDto[]> resultItem, IExternalSearchRequest request, IDictionary<string, object> config)
         {
             var metadata = new EntityMetadataPart();
 
-            PopulateMetadata(metadata, resultItem, request);
+            PopulateMetadata(metadata, resultItem, request, config);
 
             return metadata;
         }
 
-        private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<ResultsDto[]> resultItem,
-            IExternalSearchRequest request)
+        private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<ResultsDto[]> resultItem, IExternalSearchRequest request, IDictionary<string, object> config)
         {
             var code = new EntityCode(request.EntityMetaData.EntityType, "RestApi",
                 $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}"
@@ -387,6 +385,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             metadata.Name = request.EntityMetaData.Name;
             metadata.OriginEntityCode = code;
             metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
+
+            config.TryGetValue(Constants.KeyName.IncludeConfidenceScore, out var includeConfidenceScore);
 
             foreach (var enrichmentResult in resultItem.Data)
             {
@@ -398,7 +398,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     metadata.Properties[key] = en.Current.Value?.ToString();
                 }
 
-                if (enrichmentResult.Data.Count > 0)
+                if (enrichmentResult.Data.Count > 0 && includeConfidenceScore is true)
                 {
                     metadata.Properties[RestApiVocabulary.Organization.ConfidenceScore] = enrichmentResult.Score.ToString(CultureInfo.InvariantCulture);
                 }

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -387,6 +387,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             config.TryGetValue(Constants.KeyName.IncludeConfidenceScore, out var includeConfidenceScore);
+            config.TryGetValue(ExternalSearchConstants.EnricherV2SendToLandingZone, out var isEnricherV2);
 
             foreach (var enrichmentResult in resultItem.Data)
             {
@@ -398,7 +399,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     metadata.Properties[key] = en.Current.Value?.ToString();
                 }
 
-                if (enrichmentResult.Data.Count > 0 && includeConfidenceScore is true)
+                if (enrichmentResult.Data.Count > 0 && (isEnricherV2 is true ||  includeConfidenceScore is true))
                 {
                     metadata.Properties[RestApiVocabulary.Organization.ConfidenceScore] = enrichmentResult.Score.ToString(CultureInfo.InvariantCulture);
                 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#55156](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/55156)

A new `Include Confidence Score` control for REST API Enricher
<img width="1898" height="939" alt="image" src="https://github.com/user-attachments/assets/e1f6c6aa-f3c9-4d7b-8cc7-74f7a06343c1" />

When not including Confidence Score in results
<img width="1914" height="944" alt="image" src="https://github.com/user-attachments/assets/5e8a38e2-c13d-413c-b5c0-58197ce2dd0a" />

When including Confidence Score in results
<img width="1925" height="944" alt="image" src="https://github.com/user-attachments/assets/f9b77008-148c-41a6-93ee-41ff015058c6" />


## How has it been tested? <!-- Remove if not needed -->
Manually in local

