### PR TITLE
feat: REST API enricher v2

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -1,6 +1,7 @@
 ### Features
 - Added exception messages along the external search pipeline to improve clarity and logging
 - Introduced the new Edit Script control
+- Add helper methods
 
 ### Fix
 - Retry ExecuteSearch if TooManyRequests

--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -1,7 +1,6 @@
 ### Features
 - Added exception messages along the external search pipeline to improve clarity and logging
 - Introduced the new Edit Script control
-- Add helper methods
 
 ### Fix
 - Retry ExecuteSearch if TooManyRequests

--- a/docs/4.6.2-release-notes.md
+++ b/docs/4.6.2-release-notes.md
@@ -1,2 +1,2 @@
 ### Features
-- Add helper methods
+- Implement REST API v2 with a single processing script that provides greater flexibility

--- a/docs/4.6.2-release-notes.md
+++ b/docs/4.6.2-release-notes.md
@@ -1,0 +1,2 @@
+### Features
+- Add helper methods

--- a/src/ExternalSearch.Providers.RestApi/Constants.cs
+++ b/src/ExternalSearch.Providers.RestApi/Constants.cs
@@ -55,11 +55,18 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             public const string VocabularyAndProperties = "vocabularyAndProperties";
             public const string ProcessRequestScript = "processRequestScript";
             public const string ProcessResponseScript = "processResponseScript";
+            public const string ProcessScript = "processScript";
+            public const string Version = "version";
         }
 
         public static string About { get; set; } = "The REST API Enricher retrieves data resources from a wide variety of endpoints, offering flexible and seamless access to diverse data sources.";
         public static string Icon { get; set; } = "Resources.RestApi.svg";
         public static string Domain { get; set; } = "N/A";
+
+        public const string Get = "GET";
+        public const string Post = "POST";
+        public const string V1 = "V1";
+        public const string V2 = "V2";
 
         private static readonly HashSet<string> SupportedMethodsHashSet = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -67,10 +74,15 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             Post,
         };
 
-        public const string Get = "GET";
-        public const string Post = "POST";
+
+        private static readonly HashSet<string> SupportedVersionsHashSet = new(StringComparer.OrdinalIgnoreCase)
+        {
+            V1,
+            V2
+        };
 
         public static ICollection<string> SupportedMethods => SupportedMethodsHashSet;
+        public static ICollection<string> SupportedVersions => SupportedVersionsHashSet;
 
         public static IEnumerable<Control> Properties { get; set; } = new List<Control>
         {
@@ -81,6 +93,20 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 IsRequired = true,
                 Name = KeyName.AcceptedEntityType,
                 Help = "The business domain that defines the golden records you want to enrich (e.g., /Organization)."
+            },
+            new()
+            {
+                DisplayName = "Version",
+                Type = "option",
+                IsRequired = true,
+                Name = KeyName.Version,
+                Help = "The version of REST API enricher. When set to V1, Process Request Script and Process Response Script will be used. When set to V2, only a single Process Script will be used.",
+                SourceType = ControlSourceType.Dynamic,
+                Source = RestApiExtendedConfigurationProvider.SourceName,
+                Options = new Dictionary<string, object>
+                {
+                    { "defaultValue", "v2" }
+                }
             },
             new()
             {
@@ -98,6 +124,13 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                         Name = KeyName.Url,
                         Operator = ControlDependencyOperator.Exists,
                         UnfulfilledAction = ControlDependencyUnfulfilledAction.None,
+                    },
+                    new ControlDisplayDependency
+                    {
+                        Name = KeyName.Version,
+                        Operator = ControlDependencyOperator.NotEquals,
+                        Value = "v2",
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
                     }
                 ],
             },
@@ -107,7 +140,17 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 Type = "input",
                 IsRequired = true,
                 Name = KeyName.Url,
-                Help = "The endpoint URL that will be used for retrieving data."
+                Help = "The endpoint URL that will be used for retrieving data.",
+                DisplayDependencies =
+                [
+                    new ControlDisplayDependency
+                    {
+                        Name = KeyName.Version,
+                        Operator = ControlDependencyOperator.NotEquals,
+                        Value = "v2",
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    }
+                ],
             },
             new()
             {
@@ -115,7 +158,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 Type = "password",
                 IsRequired = false,
                 Name = KeyName.ApiKey,
-                Help = "The authorization api key for the endpoint that will be used for retrieving data."
+                Help = "The authorization api key for the endpoint that will be used for retrieving data.",
             },
             new()
             {
@@ -123,7 +166,17 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 Type = "multiline",
                 IsRequired = false,
                 Name = KeyName.Headers,
-                Help = "The headers for the endpoint that will be used for retrieving data."
+                Help = "The headers for the endpoint that will be used for retrieving data.",
+                DisplayDependencies =
+                [
+                    new ControlDisplayDependency
+                    {
+                        Name = KeyName.Version,
+                        Operator = ControlDependencyOperator.NotEquals,
+                        Value = "v2",
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    }
+                ],
             },
             new()
             {
@@ -140,7 +193,17 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 IsRequired = false,
                 Name = KeyName.ProcessRequestScript,
                 Help = "The JavaScript script that will be used to process the request to external source.",
-                Options = new Dictionary<string, object>() {{"Scripting Language", "JavaScript"}}
+                Options = new Dictionary<string, object>() {{"Scripting Language", "JavaScript"}},
+                DisplayDependencies =
+                [
+                    new ControlDisplayDependency
+                    {
+                        Name = KeyName.Version,
+                        Operator = ControlDependencyOperator.NotEquals,
+                        Value = "v2",
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    }
+                ],
             },
             new()
             {
@@ -149,7 +212,36 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 IsRequired = false,
                 Name = KeyName.ProcessResponseScript,
                 Help = "The JavaScript script that will be used to process the response from external source.",
-                Options = new Dictionary<string, object>() {{"Scripting Language", "JavaScript"}}
+                Options = new Dictionary<string, object>() {{"Scripting Language", "JavaScript"}},
+                DisplayDependencies =
+                [
+                    new ControlDisplayDependency
+                    {
+                        Name = KeyName.Version,
+                        Operator = ControlDependencyOperator.NotEquals,
+                        Value = "v2",
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    }
+                ],
+            },
+            new()
+            {
+                DisplayName = "Process Script",
+                Type = "scriptEditor",
+                IsRequired = false,
+                Name = KeyName.ProcessScript,
+                Help = "The JavaScript script that will be used to request and process the response from external source.",
+                Options = new Dictionary<string, object>() {{"Scripting Language", "JavaScript"}},
+                DisplayDependencies =
+                [
+                    new ControlDisplayDependency
+                    {
+                        Name = KeyName.Version,
+                        Operator = ControlDependencyOperator.Equals,
+                        Value = "v2",
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    },
+                ],
             },
         };
 

--- a/src/ExternalSearch.Providers.RestApi/Helper/Cache.cs
+++ b/src/ExternalSearch.Providers.RestApi/Helper/Cache.cs
@@ -1,26 +1,46 @@
 using System;
-using CluedIn.Core;
+using System.Collections.Concurrent;
+using ExecutionContext = CluedIn.Core.ExecutionContext;
 
 namespace CluedIn.ExternalSearch.Providers.RestApi.Helper;
 
 public class Cache(ExecutionContext executionContext)
 {
+    private static readonly ConcurrentDictionary<string, object> Locks = new();
+
+    private object GetLock(string key)
+    {
+        var lockKey = $"{executionContext.Organization.Id}:{key}";
+        return Locks.GetOrAdd(lockKey, _ => new object());
+    }
+
     public object Get(string key)
     {
+        if (string.IsNullOrWhiteSpace(key)) 
+            throw new ArgumentNullException(nameof(key), "Cache key cannot be empty.");
+
         var cached = executionContext.ApplicationContext.System.Cache.GetItem<object>($"{executionContext.Organization.Id}_{key}");
         return cached;
     }
 
     public void Set(string key, object value, double expiration)
     {
-        var keyWithOrgId = $"{executionContext.Organization.Id}_{key}";
-        var cached = executionContext.ApplicationContext.System.Cache.GetItem<object>(keyWithOrgId);
+        if (string.IsNullOrWhiteSpace(key)) 
+            throw new ArgumentNullException(nameof(key), "Cache key cannot be empty.");
 
-        if (cached != null)
+        var lockObj = GetLock(key);
+        lock (lockObj)
         {
-            return;
-        }
+            var keyWithOrgId = $"{executionContext.Organization.Id}_{key}";
+            var cached = executionContext.ApplicationContext.System.Cache.GetItem<object>(keyWithOrgId);
 
-        executionContext.ApplicationContext.System.Cache.SetItem(keyWithOrgId, value, DateTimeOffset.Now.AddMilliseconds(expiration));
+            // The application cache in core is not allow to overwrite existing items, so we check if it exists before adding
+            if (cached != null)
+            {
+                return;
+            }
+
+            executionContext.ApplicationContext.System.Cache.SetItem(keyWithOrgId, value, expiration > 0 ? DateTimeOffset.Now.AddMilliseconds(expiration) : null);
+        }
     }
 }

--- a/src/ExternalSearch.Providers.RestApi/Helper/Cache.cs
+++ b/src/ExternalSearch.Providers.RestApi/Helper/Cache.cs
@@ -1,19 +1,10 @@
 using System;
-using System.Collections.Concurrent;
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 
 namespace CluedIn.ExternalSearch.Providers.RestApi.Helper;
 
 public class Cache(ExecutionContext executionContext)
 {
-    private static readonly ConcurrentDictionary<string, object> Locks = new();
-
-    private object GetLock(string key)
-    {
-        var lockKey = $"{executionContext.Organization.Id}:{key}";
-        return Locks.GetOrAdd(lockKey, _ => new object());
-    }
-
     public object Get(string key)
     {
         if (string.IsNullOrWhiteSpace(key)) 
@@ -28,19 +19,15 @@ public class Cache(ExecutionContext executionContext)
         if (string.IsNullOrWhiteSpace(key)) 
             throw new ArgumentNullException(nameof(key), "Cache key cannot be empty.");
 
-        var lockObj = GetLock(key);
-        lock (lockObj)
+        var keyWithOrgId = $"{executionContext.Organization.Id}_{key}";
+        var cached = executionContext.ApplicationContext.System.Cache.GetItem<object>(keyWithOrgId);
+
+        // The application cache in core is not allow to overwrite existing items, so we check if it exists before adding
+        if (cached != null)
         {
-            var keyWithOrgId = $"{executionContext.Organization.Id}_{key}";
-            var cached = executionContext.ApplicationContext.System.Cache.GetItem<object>(keyWithOrgId);
-
-            // The application cache in core is not allow to overwrite existing items, so we check if it exists before adding
-            if (cached != null)
-            {
-                return;
-            }
-
-            executionContext.ApplicationContext.System.Cache.SetItem(keyWithOrgId, value, expiration > 0 ? DateTimeOffset.Now.AddMilliseconds(expiration) : null);
+            return;
         }
+
+        executionContext.ApplicationContext.System.Cache.SetItem(keyWithOrgId, value, expiration > 0 ? DateTimeOffset.Now.AddMilliseconds(expiration) : null);
     }
 }

--- a/src/ExternalSearch.Providers.RestApi/Helper/Cache.cs
+++ b/src/ExternalSearch.Providers.RestApi/Helper/Cache.cs
@@ -1,0 +1,26 @@
+using System;
+using CluedIn.Core;
+
+namespace CluedIn.ExternalSearch.Providers.RestApi.Helper;
+
+public class Cache(ExecutionContext executionContext)
+{
+    public object Get(string key)
+    {
+        var cached = executionContext.ApplicationContext.System.Cache.GetItem<object>($"{executionContext.Organization.Id}_{key}");
+        return cached;
+    }
+
+    public void Set(string key, object value, double expiration)
+    {
+        var keyWithOrgId = $"{executionContext.Organization.Id}_{key}";
+        var cached = executionContext.ApplicationContext.System.Cache.GetItem<object>(keyWithOrgId);
+
+        if (cached != null)
+        {
+            return;
+        }
+
+        executionContext.ApplicationContext.System.Cache.SetItem(keyWithOrgId, value, DateTimeOffset.Now.AddMilliseconds(expiration));
+    }
+}

--- a/src/ExternalSearch.Providers.RestApi/Helper/StringEncodingHelper.cs
+++ b/src/ExternalSearch.Providers.RestApi/Helper/StringEncodingHelper.cs
@@ -25,7 +25,7 @@ public class StringEncodingHelper
         }
         catch (FormatException)
         {
-            throw new ArgumentNullException(nameof(base64), "Base64 value is in an incorrect format");
+            throw new ArgumentException("Base64 value is in an incorrect format", nameof(base64));
         }
     }
 

--- a/src/ExternalSearch.Providers.RestApi/Helper/StringEncodingHelper.cs
+++ b/src/ExternalSearch.Providers.RestApi/Helper/StringEncodingHelper.cs
@@ -8,7 +8,7 @@ public class StringEncodingHelper
     public string ToBase64(string value)
     {
         if (value == null)
-            throw new ArgumentNullException(nameof(value), "Value to be converted to base64 cannot be empty.");
+            throw new ArgumentNullException(nameof(value), "Value to be converted to base64 cannot be null.");
 
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
     }

--- a/src/ExternalSearch.Providers.RestApi/Helper/StringEncodingHelper.cs
+++ b/src/ExternalSearch.Providers.RestApi/Helper/StringEncodingHelper.cs
@@ -5,28 +5,36 @@ namespace CluedIn.ExternalSearch.Providers.RestApi.Helper;
 
 public class StringEncodingHelper
 {
-    public static string ToBase64(string value)
+    public string ToBase64(string value)
     {
         if (value == null)
-            throw new ArgumentNullException(nameof(value));
+            throw new ArgumentNullException(nameof(value), "Value to be converted to base64 cannot be empty.");
 
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
     }
 
-    public static string FromBase64(string base64)
+    public string FromBase64(string base64)
     {
-        if (base64 == null) return null;
+        if (string.IsNullOrWhiteSpace(base64))
+            throw new ArgumentNullException(nameof(base64), "Base64 value cannot be empty.");
 
-        var bytes = Convert.FromBase64String(base64);
-        return Encoding.UTF8.GetString(bytes);
+        try
+        {
+            var bytes = Convert.FromBase64String(base64);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        catch (FormatException)
+        {
+            throw new ArgumentNullException(nameof(base64), "Base64 value is in an incorrect format");
+        }
     }
 
-    public static string UrlEncode(string value)
+    public string UrlEncode(string value)
     {
         return value == null ? null : Uri.EscapeDataString(value);
     }
 
-    public static string UrlDecode(string value)
+    public string UrlDecode(string value)
     {
         return value == null ? null : Uri.UnescapeDataString(value);
     }

--- a/src/ExternalSearch.Providers.RestApi/Helper/StringEncodingHelper.cs
+++ b/src/ExternalSearch.Providers.RestApi/Helper/StringEncodingHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Text;
+
+namespace CluedIn.ExternalSearch.Providers.RestApi.Helper;
+
+public class StringEncodingHelper
+{
+    public static string ToBase64(string value)
+    {
+        if (value == null)
+            throw new ArgumentNullException(nameof(value));
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+    }
+
+    public static string FromBase64(string base64)
+    {
+        if (base64 == null) return null;
+
+        var bytes = Convert.FromBase64String(base64);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    public static string UrlEncode(string value)
+    {
+        return value == null ? null : Uri.EscapeDataString(value);
+    }
+
+    public static string UrlDecode(string value)
+    {
+        return value == null ? null : Uri.UnescapeDataString(value);
+    }
+}

--- a/src/ExternalSearch.Providers.RestApi/Models/QueryParameters.cs
+++ b/src/ExternalSearch.Providers.RestApi/Models/QueryParameters.cs
@@ -9,5 +9,6 @@ public class QueryParameters
     public string Headers { get; set; }
     public string ProcessRequestScript { get; set; }
     public string ProcessResponseScript { get; set; }
+    public string ProcessScript { get; set; }
 }
 

--- a/src/ExternalSearch.Providers.RestApi/Models/RequestDto.cs
+++ b/src/ExternalSearch.Providers.RestApi/Models/RequestDto.cs
@@ -30,6 +30,8 @@ public class RequestDto
 
     public void AddHeader(string key, string value)
     {
+        Headers ??= new List<HeaderDto>();
+
         Headers.Add(new HeaderDto
         {
             Key = key,

--- a/src/ExternalSearch.Providers.RestApi/Models/RequestDto.cs
+++ b/src/ExternalSearch.Providers.RestApi/Models/RequestDto.cs
@@ -27,6 +27,15 @@ public class RequestDto
     /// The body content of the HTTP request.
     /// </summary>
     public object Body { get; set; }
+
+    public void AddHeader(string key, string value)
+    {
+        Headers.Add(new HeaderDto
+        {
+            Key = key,
+            Value = value
+        });
+    }
 }
 
 /// <summary>

--- a/src/ExternalSearch.Providers.RestApi/Models/ScriptHttpClient.cs
+++ b/src/ExternalSearch.Providers.RestApi/Models/ScriptHttpClient.cs
@@ -1,0 +1,84 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CluedIn.ExternalSearch.Providers.RestApi.Models
+{
+    public class ScriptHttpClient
+    {
+        private readonly TimeSpan _timeout = TimeSpan.FromSeconds(10);
+
+        public ResponseDto Send(object request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var requestJson = JsonConvert.SerializeObject(request);
+
+            var requestDto = JsonConvert.DeserializeObject<RequestDto>(requestJson)
+                          ?? throw new InvalidOperationException("Failed to deserialize request");
+
+            if (string.IsNullOrWhiteSpace(requestDto.Url))
+                throw new ArgumentException("Request URL is required");
+
+            if (!Uri.TryCreate(requestDto.Url, UriKind.Absolute, out var uri))
+                throw new ArgumentException($"Invalid URL: {requestDto.Url}");
+
+            var method = string.IsNullOrWhiteSpace(requestDto.Method)
+                ? HttpMethod.Get.Method
+                : requestDto.Method;
+
+
+            using var client = new HttpClient();
+            client.Timeout = _timeout;
+
+            using var message = new HttpRequestMessage(new HttpMethod(method), uri);
+
+            if (requestDto.Headers != null)
+            {
+                foreach (var header in requestDto.Headers.Where(header => !string.IsNullOrWhiteSpace(header.Key)))
+                {
+                    message.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            if (method.Equals(HttpMethod.Post.Method, StringComparison.OrdinalIgnoreCase)
+                && requestDto.Body != null)
+            {
+                var json = JsonConvert.SerializeObject(requestDto.Body);
+                message.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+
+            HttpResponseMessage response;
+            try
+            {
+                response = client.SendAsync(message)
+                                 .GetAwaiter()
+                                 .GetResult();
+            }
+            catch (TaskCanceledException ex)
+            {
+                throw new TimeoutException("HTTP request timed out", ex);
+            }
+
+            var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+
+            return new ResponseDto
+            {
+                HttpStatus = response.StatusCode.ToString(),
+                Content = content,
+                ContentType = response.Content?.Headers.ContentType?.ToString(),
+                Headers = response.Headers
+                    .Select(h => new HeaderDto
+                    {
+                        Key = h.Key,
+                        Value = string.Join(",", h.Value)
+                    })
+                    .ToList()
+            };
+        }
+    }
+}

--- a/src/ExternalSearch.Providers.RestApi/Models/ScriptHttpClient.cs
+++ b/src/ExternalSearch.Providers.RestApi/Models/ScriptHttpClient.cs
@@ -5,67 +5,74 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CluedIn.ExternalSearch.Providers.RestApi.Models
+namespace CluedIn.ExternalSearch.Providers.RestApi.Models;
+
+public class ScriptHttpClient
 {
-    public class ScriptHttpClient
+    private static readonly HttpClient Client = new()
     {
-        private readonly TimeSpan _timeout = TimeSpan.FromSeconds(10);
+        Timeout = TimeSpan.FromSeconds(10)
+    };
 
-        public ResponseDto Send(object request)
+    /// <summary>
+    /// Sends an HTTP request based on the supplied request object and returns a structured response.
+    /// </summary>
+    /// <param name="request">
+    /// An object that can be serialized into a <see cref="RequestDto"/>, containing the URL,
+    /// HTTP method, headers, and optional body to be sent.
+    /// </param>
+    /// <returns>
+    /// A <see cref="ResponseDto"/> containing the HTTP status, response content, headers,
+    /// and content type returned by the remote server.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the request object cannot be deserialized into a <see cref="RequestDto"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when the request URL is missing or invalid.</exception>
+    /// <exception cref="TimeoutException">Thrown when the HTTP request exceeds the configured timeout.</exception>
+    public ResponseDto Send(object request)
+    {
+        if (request == null)
+            throw new ArgumentNullException(nameof(request));
+
+        var requestJson = JsonConvert.SerializeObject(request);
+
+        var requestDto = JsonConvert.DeserializeObject<RequestDto>(requestJson)
+                         ?? throw new InvalidOperationException("Failed to deserialize request");
+
+        if (string.IsNullOrWhiteSpace(requestDto.Url))
+            throw new ArgumentException("Request URL is required");
+
+        if (!Uri.TryCreate(requestDto.Url, UriKind.Absolute, out var uri))
+            throw new ArgumentException($"Invalid URL: {requestDto.Url}");
+
+        var method = string.IsNullOrWhiteSpace(requestDto.Method)
+            ? HttpMethod.Get.Method
+            : requestDto.Method;
+
+
+        using var message = new HttpRequestMessage(new HttpMethod(method), uri);
+
+        if (requestDto.Headers != null)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-
-            var requestJson = JsonConvert.SerializeObject(request);
-
-            var requestDto = JsonConvert.DeserializeObject<RequestDto>(requestJson)
-                          ?? throw new InvalidOperationException("Failed to deserialize request");
-
-            if (string.IsNullOrWhiteSpace(requestDto.Url))
-                throw new ArgumentException("Request URL is required");
-
-            if (!Uri.TryCreate(requestDto.Url, UriKind.Absolute, out var uri))
-                throw new ArgumentException($"Invalid URL: {requestDto.Url}");
-
-            var method = string.IsNullOrWhiteSpace(requestDto.Method)
-                ? HttpMethod.Get.Method
-                : requestDto.Method;
-
-
-            using var client = new HttpClient();
-            client.Timeout = _timeout;
-
-            using var message = new HttpRequestMessage(new HttpMethod(method), uri);
-
-            if (requestDto.Headers != null)
+            foreach (var header in requestDto.Headers.Where(header => !string.IsNullOrWhiteSpace(header.Key)))
             {
-                foreach (var header in requestDto.Headers.Where(header => !string.IsNullOrWhiteSpace(header.Key)))
-                {
-                    message.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                }
+                message.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
+        }
 
-            if (method.Equals(HttpMethod.Post.Method, StringComparison.OrdinalIgnoreCase)
-                && requestDto.Body != null)
-            {
-                var json = JsonConvert.SerializeObject(requestDto.Body);
-                message.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            }
+        if (method.Equals(HttpMethod.Post.Method, StringComparison.OrdinalIgnoreCase)
+            && requestDto.Body != null)
+        {
+            var json = JsonConvert.SerializeObject(requestDto.Body);
+            message.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        }
 
-            HttpResponseMessage response;
-            try
-            {
-                response = client.SendAsync(message)
-                                 .GetAwaiter()
-                                 .GetResult();
-            }
-            catch (TaskCanceledException ex)
-            {
-                throw new TimeoutException("HTTP request timed out", ex);
-            }
-
+        try
+        {
+            using var response = Client.SendAsync(message)
+                .GetAwaiter()
+                .GetResult();
             var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-
             return new ResponseDto
             {
                 HttpStatus = response.StatusCode.ToString(),
@@ -79,6 +86,10 @@ namespace CluedIn.ExternalSearch.Providers.RestApi.Models
                     })
                     .ToList()
             };
+        }
+        catch (TaskCanceledException ex)
+        {
+            throw new TimeoutException("HTTP request timed out", ex);
         }
     }
 }

--- a/src/ExternalSearch.Providers.RestApi/Models/ScriptHttpClient.cs
+++ b/src/ExternalSearch.Providers.RestApi/Models/ScriptHttpClient.cs
@@ -11,7 +11,7 @@ public class ScriptHttpClient
 {
     private static readonly HttpClient Client = new()
     {
-        Timeout = TimeSpan.FromSeconds(10)
+        Timeout = TimeSpan.FromSeconds(60)
     };
 
     /// <summary>
@@ -60,7 +60,7 @@ public class ScriptHttpClient
             }
         }
 
-        if (method.Equals(HttpMethod.Post.Method, StringComparison.OrdinalIgnoreCase)
+        if (!method.Equals(HttpMethod.Get.Method, StringComparison.OrdinalIgnoreCase)
             && requestDto.Body != null)
         {
             var json = JsonConvert.SerializeObject(requestDto.Body);

--- a/src/ExternalSearch.Providers.RestApi/RestApiExtendedConfigurationProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExtendedConfigurationProvider.cs
@@ -16,6 +16,10 @@ internal class RestApiExtendedConfigurationProvider : IExtendedConfigurationProv
         .Select(name => new Option(name.ToLowerInvariant(), name))
         .ToArray();
 
+    private static readonly Option[] VersionOptions = Constants.SupportedVersions
+        .Select(name => new Option(name.ToLowerInvariant(), name))
+        .ToArray();
+
     public Task<CanHandleResponse> CanHandle(ExecutionContext context, ExtendedConfigurationRequest request)
     {
         return Task.FromResult(new CanHandleResponse
@@ -29,6 +33,7 @@ internal class RestApiExtendedConfigurationProvider : IExtendedConfigurationProv
         var found = request.Key switch
         {
             Constants.KeyName.Method => HandleMethods().Data.SingleOrDefault(item => item.Value.Equals(request.Value, StringComparison.OrdinalIgnoreCase)),
+            Constants.KeyName.Version => HandleVersions().Data.SingleOrDefault(item => item.Value.Equals(request.Value, StringComparison.OrdinalIgnoreCase)),
             _ => null,
         };
 
@@ -46,8 +51,21 @@ internal class RestApiExtendedConfigurationProvider : IExtendedConfigurationProv
         return Task.FromResult(request.Key switch
         {
             Constants.KeyName.Method => HandleMethods(),
+            Constants.KeyName.Version => HandleVersions(),
+
             _ => ResolveOptionsResponse.Empty,
         });
+    }
+
+    private static ResolveOptionsResponse HandleVersions()
+    {
+        return new ResolveOptionsResponse
+        {
+            Data = VersionOptions,
+            Total = VersionOptions.Length,
+            Page = 0,
+            Take = DefaultPageSize,
+        };
     }
 
     private static ResolveOptionsResponse HandleMethods()

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchJobData.cs
@@ -15,6 +15,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             Headers = GetValue<string>(configuration, Constants.KeyName.Headers);
             ProcessRequestScript = GetValue<string>(configuration, Constants.KeyName.ProcessRequestScript);
             ProcessResponseScript = GetValue<string>(configuration, Constants.KeyName.ProcessResponseScript);
+            ProcessScript = GetValue<string>(configuration, Constants.KeyName.ProcessScript);
+            Version = GetValue<string>(configuration, Constants.KeyName.Version);
         }
 
         public IDictionary<string, object> ToDictionary()
@@ -28,6 +30,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 { Constants.KeyName.ApiKey, ApiKey },
                 { Constants.KeyName.ProcessRequestScript, ProcessRequestScript },
                 { Constants.KeyName.ProcessResponseScript, ProcessResponseScript },
+                { Constants.KeyName.ProcessScript, ProcessScript },
+                { Constants.KeyName.Version, Version}
             };
         }
 
@@ -39,5 +43,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
         public string Headers { get; set; }
         public string ProcessRequestScript { get; set; }
         public string ProcessResponseScript { get; set; }
+        public string ProcessScript { get; set; }
+        public string Version { get; set; }
     }
 }

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -358,6 +358,75 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
         public ConnectionVerificationResult VerifyConnection(ExecutionContext executionContext, IReadOnlyDictionary<string, object> config)
         {
             var data = new RestApiExternalSearchJobData(config.ToDictionary(x => x.Key, x => x.Value));
+
+            return data.Version switch
+            {
+                // for backward compatibility
+                null or "" or "v1" => VerifyConnectionV1(executionContext, data),
+                "v2" => VerifyConnectionV2(executionContext, data),
+                _ => new ConnectionVerificationResult(false, $"Unable to verify connection due to invalid version '{data.Version}'.")
+
+            };
+        }
+
+        private static ConnectionVerificationResult VerifyConnectionV2(ExecutionContext executionContext,
+            RestApiExternalSearchJobData data)
+        {
+            var response = string.Empty;
+            var stringEncoder = new StringEncodingHelper();
+            var cache = new Cache(executionContext);
+
+            try
+            {
+                var body = string.IsNullOrWhiteSpace(data.VocabularyAndProperties) ? null : GetPropertiesTestConnection(data.VocabularyAndProperties);
+
+                if (!string.IsNullOrWhiteSpace(data.ProcessScript))
+                {
+                    using var engine = new Jint.Engine(options =>
+                    {
+                        options
+                            .LimitRecursion(64)
+                            .MaxStatements(10_000)
+                            .TimeoutInterval(TimeSpan.FromSeconds(2));
+                    });
+
+                    engine
+                        .SetValue("log", new Action<object>(o =>
+                            executionContext.Log.Log(LogLevel.Information, "User Script log: {O}", o)))
+                        .SetValue("stringEncoder", stringEncoder)
+                        .SetValue("cache", cache)
+                        .SetValue("vocabularies", body)
+                        .SetValue("http", new ScriptHttpClient());
+
+                    engine.Execute(data.ProcessScript);
+
+                    response = engine.GetValue("response").IsUndefined()
+                        ? string.Empty
+                        : engine.GetValue("response").ToString();
+                }
+
+                if (string.IsNullOrWhiteSpace(response))
+                {
+                    return new ConnectionVerificationResult(false, "Response Content after Calling User Script is null or empty");
+                }
+
+                JsonConvert.DeserializeObject<ResultsDto[]>(response);
+            }
+            catch (JsonException)
+            {
+                return new ConnectionVerificationResult(false, "Failed to deserialize user script response to ResultsDto[]. Ensure the script returns valid JSON matching the expected structure");
+            }
+            catch (Exception ex)
+            {
+                return new ConnectionVerificationResult(false, ex.Message);
+            }
+
+            return new ConnectionVerificationResult(true);
+        }
+
+        private static ConnectionVerificationResult VerifyConnectionV1(ExecutionContext executionContext,
+            RestApiExternalSearchJobData data)
+        {
             var queryParametersTestConnection = new QueryParameters
             {
                 Url = data.Url,
@@ -457,12 +526,12 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     return new ConnectionVerificationResult(false, "Response Content after Calling User Script is null or empty");
                 }
 
-                if (responseDto.HttpStatus == HttpStatusCode.TooManyRequests.ToString()) return new ConnectionVerificationResult(false, $"Too many requests - Call returned HTTP {responseDto.HttpStatus} - {responseDto.Content}");
+                if (responseDto.HttpStatus == nameof(HttpStatusCode.TooManyRequests)) return new ConnectionVerificationResult(false, $"Too many requests - Call returned HTTP {responseDto.HttpStatus} - {responseDto.Content}");
 
-                return responseDto.HttpStatus != HttpStatusCode.OK.ToString() ? new ConnectionVerificationResult(false, $"Call returned HTTP {responseDto.HttpStatus} - {responseDto.Content}") : new ConnectionVerificationResult(true);
+                return responseDto.HttpStatus != nameof(HttpStatusCode.OK) ? new ConnectionVerificationResult(false, $"Call returned HTTP {responseDto.HttpStatus} - {responseDto.Content}") : new ConnectionVerificationResult(true);
             }
-            catch (Exception ex) 
-            { 
+            catch (Exception ex)
+            {
                 return new ConnectionVerificationResult(false, ex.Message);
             }
         }

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -129,6 +129,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessScript))
             {
+                var processScript = ReplaceTokens(queryParameters.ProcessScript, queryParameters);
                 using var engine = new Jint.Engine(options =>
                 {
                     options
@@ -146,7 +147,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                         JsonConvert.DeserializeObject<List<PropertyDto>>(queryParameters.Body ?? string.Empty))
                     .SetValue("http", new ScriptHttpClient());
 
-                engine.Execute(queryParameters.ProcessScript);
+                engine.Execute(processScript);
 
                 response = engine.GetValue("response").IsUndefined()
                     ? string.Empty
@@ -202,6 +203,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessRequestScript))
             {
+                var processRequestScript = ReplaceTokens(queryParameters.ProcessRequestScript, queryParameters);
                 using var engine = new Jint.Engine(options =>
                     {
                         options
@@ -217,7 +219,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     .SetValue("cache", cache)
                     .SetValue("vocabularies",
                         JsonConvert.DeserializeObject<List<PropertyDto>>(queryParameters.Body ?? string.Empty))
-                    .Execute(queryParameters.ProcessRequestScript);
+                    .Execute(processRequestScript);
 
                 request = engine.GetValue("request").ToObject() as RequestDto;
             }
@@ -375,6 +377,13 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             var response = string.Empty;
             var stringEncoder = new StringEncodingHelper();
             var cache = new Cache(executionContext);
+            var queryParametersTestConnection = new QueryParameters
+            {
+                Body = data.VocabularyAndProperties,
+                ApiKey = data.ApiKey,
+                Headers = data.Headers,
+                ProcessScript = data.ProcessScript
+            };
 
             try
             {
@@ -382,6 +391,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
                 if (!string.IsNullOrWhiteSpace(data.ProcessScript))
                 {
+                    var processScript = ReplaceTokens(data.ProcessScript, queryParametersTestConnection);
                     using var engine = new Jint.Engine(options =>
                     {
                         options
@@ -398,7 +408,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                         .SetValue("vocabularies", body)
                         .SetValue("http", new ScriptHttpClient());
 
-                    engine.Execute(data.ProcessScript);
+                    engine.Execute(processScript);
 
                     response = engine.GetValue("response").IsUndefined()
                         ? string.Empty
@@ -438,31 +448,31 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 ProcessResponseScript = data.ProcessResponseScript
             };
 
-            if (string.IsNullOrWhiteSpace(queryParametersTestConnection.Url))
+            if (string.IsNullOrWhiteSpace(data.Url))
             {
                 return new ConnectionVerificationResult(false, "URL must not be blank");
             }
 
-            if (string.IsNullOrWhiteSpace(queryParametersTestConnection.Method))
+            if (string.IsNullOrWhiteSpace(data.Method))
             {
                 return new ConnectionVerificationResult(false, "Method must not be blank");
             }
 
-            if (queryParametersTestConnection.Url.Contains("Vocabulary:"))
+            if (data.Url.Contains("Vocabulary:"))
             {
                 return new ConnectionVerificationResult(false, "Please replace {Vocabulary:xxx} in url with actual value to test connection");
             }
 
             try
             {
-                var body = string.IsNullOrWhiteSpace(queryParametersTestConnection.Body) ? null : GetPropertiesTestConnection(queryParametersTestConnection.Body);
-                var url = ReplaceTokens(queryParametersTestConnection.Url, queryParametersTestConnection);
+                var body = string.IsNullOrWhiteSpace(data.VocabularyAndProperties) ? null : GetPropertiesTestConnection(data.VocabularyAndProperties);
+                var url = ReplaceTokens(data.Url, queryParametersTestConnection);
                 var request = new RequestDto
                 {
-                    Method = queryParametersTestConnection.Method,
+                    Method = data.Method,
                     Url = url,
                     Headers = GetHeaders(queryParametersTestConnection),
-                    ApiKey = queryParametersTestConnection.ApiKey,
+                    ApiKey = data.ApiKey,
                     Body = new BodyDto
                     {
                         Properties = body
@@ -472,14 +482,15 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 var stringEncoder = new StringEncodingHelper();
                 var cache = new Cache(executionContext);
 
-                if (!string.IsNullOrWhiteSpace(queryParametersTestConnection.ProcessRequestScript))
+                if (!string.IsNullOrWhiteSpace(data.ProcessRequestScript))
                 {
+                    var processRequest = ReplaceTokens(data.ProcessRequestScript, queryParametersTestConnection);
                     using var requestEngine = new Jint.Engine()
                         .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
                         .SetValue("request", request)
                         .SetValue("stringEncoder", stringEncoder)
                         .SetValue("cache", cache)
-                        .Execute(queryParametersTestConnection.ProcessRequestScript);
+                        .Execute(processRequest);
 
                     request = requestEngine.GetValue("request").ToObject() as RequestDto;
                 }
@@ -508,7 +519,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     Headers = restResponse.Headers.Select(x => new HeaderDto { Key = x.Name, Value = x.Value?.ToString() }).ToList()
                 };
 
-                if (string.IsNullOrWhiteSpace(queryParametersTestConnection.ProcessResponseScript)) return new ConnectionVerificationResult(true);
+                if (string.IsNullOrWhiteSpace(data.ProcessResponseScript)) return new ConnectionVerificationResult(true);
 
                 using var responseEngine = new Jint.Engine()
                     .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
@@ -516,7 +527,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     .SetValue("response", responseDto)
                     .SetValue("stringEncoder", stringEncoder)
                     .SetValue("cache", cache)
-                    .Execute(queryParametersTestConnection.ProcessResponseScript);
+                    .Execute(data.ProcessResponseScript);
 
                 var response = responseEngine.GetValue("response").ToObject() as ResponseDto;
                 responseDto = response ?? throw new ApplicationException("Response after Calling User Script is null");

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -215,6 +215,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     .SetValue("request", request)
                     .SetValue("stringEncoder", stringEncoder)
                     .SetValue("cache", cache)
+                    .SetValue("vocabularies",
+                        JsonConvert.DeserializeObject<List<PropertyDto>>(queryParameters.Body ?? string.Empty))
                     .Execute(queryParameters.ProcessRequestScript);
 
                 request = engine.GetValue("request").ToObject() as RequestDto;
@@ -269,6 +271,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     .SetValue("response", responseDto)
                     .SetValue("stringEncoder", stringEncoder)
                     .SetValue("cache", cache)
+                    .SetValue("vocabularies",
+                        JsonConvert.DeserializeObject<List<PropertyDto>>(queryParameters.Body ?? string.Empty))
                     .Execute(queryParameters.ProcessResponseScript);
 
                 var response = engine.GetValue("response").IsUndefined()

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -101,11 +101,67 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
         public IEnumerable<IExternalSearchQueryResult> ExecuteSearch(ExecutionContext context, IExternalSearchQuery query, IDictionary<string, object> config, IProvider provider)
         {
-            return ActionExtensions.ExecuteWithRetry(
-                () => InternalExecuteSearch(context, query).ToArray(), // important we need to materialize the enumerable for ExecuteWithRetry to work
-                retryCount: 1000,
-                isTransient: ex => ex.ToString().Contains("TooManyRequests")
-            );
+            var versionSelected = query.QueryParameters.TryGetValue("version", out var version)
+                ? version.FirstOrDefault()?.ToLowerInvariant()
+                : string.Empty;
+
+            switch (versionSelected)
+            {
+                // for backward compatibility
+                case null or "" or "v1":
+                    return ActionExtensions.ExecuteWithRetry(
+                        () => InternalExecuteSearch(context, query).ToArray(), // important we need to materialize the enumerable for ExecuteWithRetry to work
+                        retryCount: 1000,
+                        isTransient: ex => ex.ToString().Contains("TooManyRequests")
+                    );
+                case "v2":
+                    return ActionExtensions.ExecuteWithRetry(
+                        () => InternalExecuteSearchV2(context, query).ToArray(),
+                        retryCount: 1000,
+                        isTransient: ex => ex.ToString().Contains("TooManyRequests")
+                    );
+                default:
+                    throw new Exception("Unable to execute search due to invalid version.");
+            }
+        }
+
+        private IEnumerable<IExternalSearchQueryResult> InternalExecuteSearchV2(ExecutionContext executionContext,
+            IExternalSearchQuery query)
+        {
+            var queryParameters = GetQueryParameters(query);
+            var response = string.Empty;
+            var stringEncoder = new StringEncodingHelper();
+            var cache = new Cache(executionContext);
+
+            if (!string.IsNullOrWhiteSpace(queryParameters.ProcessScript))
+            {
+                using var engine = new Jint.Engine()
+                    .SetValue("log",
+                        new Action<object>(o =>
+                            executionContext.Log.Log(LogLevel.Information, "User Script log: {O}", o)))
+                    .SetValue("stringEncoder", stringEncoder)
+                    .SetValue("cache", cache)
+                    .SetValue("vocabularies",
+                        JsonConvert.DeserializeObject<List<PropertyDto>>(queryParameters.Body ?? string.Empty))
+                    .SetValue("http", new ScriptHttpClient())
+                    .SetValue("retry", new Action<string>(_ =>
+                    {
+                        Thread.Sleep(2000);
+                        throw new Exception("Too many requests.");
+                    })) // To have ability for retry in script
+                    .Execute(queryParameters.ProcessScript);
+
+                response = engine.GetValue("response").ToObject() as string;
+            }
+
+            if (string.IsNullOrWhiteSpace(response))
+            {
+                throw new Exception("Response after Calling User Script is null.");
+            }
+
+            var results = JsonConvert.DeserializeObject<ResultsDto[]>(response);
+
+            yield return new ExternalSearchQueryResult<ResultsDto[]>(query, results);
         }
 
         private IEnumerable<IExternalSearchQueryResult> InternalExecuteSearch(ExecutionContext executionContext, IExternalSearchQuery query)
@@ -184,7 +240,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessResponseScript))
             {
                 using var engine = new Jint.Engine()
-                    .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}" )))
+                    .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
                     .SetValue("request", request)
                     .SetValue("originalRequest", originalRequest)
                     .SetValue("response", responseDto)
@@ -204,13 +260,13 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 executionContext.Log.Log(LogLevel.Debug, $"{Name} - Response after Calling User Script\n{JsonConvert.SerializeObject(response)}");
             }
 
-            if (responseDto.HttpStatus == HttpStatusCode.TooManyRequests.ToString())
+            if (responseDto.HttpStatus == nameof(HttpStatusCode.TooManyRequests))
             {
                 Thread.Sleep(2000);
                 throw new Exception($"Too many requests - Call returned HTTP {responseDto.HttpStatus} - {responseDto.Content}"); // hack the message must start with 'Too many requests' for the core to retry
             }
 
-            if (responseDto.HttpStatus != HttpStatusCode.OK.ToString()) throw new ApplicationException($"Call returned HTTP {responseDto.HttpStatus} - {responseDto.Content}");
+            if (responseDto.HttpStatus != nameof(HttpStatusCode.OK)) throw new ApplicationException($"Call returned HTTP {responseDto.HttpStatus} - {responseDto.Content}");
 
             var results = JsonConvert.DeserializeObject<ResultsDto[]>(responseDto.Content);
 
@@ -569,6 +625,16 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 requestInfoDict.Add("processResponseScript", processResponseScript.ToString());
             }
 
+            if (configMap != null && configMap.TryGetValue(Constants.KeyName.ProcessScript, out var processScript) && !string.IsNullOrWhiteSpace(processScript?.ToString()))
+            {
+                requestInfoDict.Add("processScript", processScript.ToString());
+            }
+
+            if (configMap != null && configMap.TryGetValue(Constants.KeyName.Version, out var version) && !string.IsNullOrWhiteSpace(version?.ToString()))
+            {
+                requestInfoDict.Add("version", version.ToString());
+            }
+
             return requestInfoDict;
         }
 
@@ -706,7 +772,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 ApiKey = string.Empty,
                 Headers = string.Empty,
                 ProcessRequestScript = string.Empty,
-                ProcessResponseScript = string.Empty
+                ProcessResponseScript = string.Empty,
+                ProcessScript = string.Empty
             };
 
             if (query.QueryParameters.ContainsKey("properties"))
@@ -757,6 +824,14 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 parameters.ProcessResponseScript =
                     query.QueryParameters.TryGetValue("processResponseScript", out var processResponseScripValue)
                         ? processResponseScripValue.FirstOrDefault()
+                        : string.Empty;
+            }
+
+            if (query.QueryParameters.ContainsKey("processScript"))
+            {
+                parameters.ProcessScript =
+                    query.QueryParameters.TryGetValue("processScript", out var processScriptValue)
+                        ? processScriptValue.FirstOrDefault()
                         : string.Empty;
             }
 

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -19,8 +19,8 @@ using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
-using System.Web;
 using Castle.MicroKernel.Registration;
+using CluedIn.ExternalSearch.Providers.RestApi.Helper;
 using CluedIn.ExternalSearch.Providers.RestApi.Vocabularies;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -108,13 +108,13 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             );
         }
 
-        private IEnumerable<IExternalSearchQueryResult> InternalExecuteSearch(ExecutionContext context, IExternalSearchQuery query)
+        private IEnumerable<IExternalSearchQueryResult> InternalExecuteSearch(ExecutionContext executionContext, IExternalSearchQuery query)
         {
             var queryParameters = GetQueryParameters(query);
 
             if (string.IsNullOrEmpty(queryParameters.Url))
             {
-                context.Log.LogTrace("No parameter for '{Identifier}' in query, skipping execute search",
+                executionContext.Log.LogTrace("No parameter for '{Identifier}' in query, skipping execute search",
                     ExternalSearchQueryParameter.Identifier);
             }
 
@@ -134,12 +134,16 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             };
 
             var request = originalRequest;
+            var stringEncoder = new StringEncodingHelper();
+            var cache = new Cache(executionContext);
 
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessRequestScript))
             {
                 using var engine = new Jint.Engine()
-                    .SetValue("log", new Action<object>(o => context.Log.Log(LogLevel.Information, $"User Script log: {o}")))
+                    .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
                     .SetValue("request", request)
+                    .SetValue("stringEncoder", stringEncoder)
+                    .SetValue("cache", cache)
                     .Execute(queryParameters.ProcessRequestScript);
 
                 request = engine.GetValue("request").ToObject() as RequestDto;
@@ -152,7 +156,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             if (string.IsNullOrWhiteSpace(request.Url))
             {
-                context.Log.LogTrace($"Skipped enrichment for record {Name} because URL is null or empty");
+                executionContext.Log.LogTrace($"Skipped enrichment for record {Name} because URL is null or empty");
                 throw new Exception("URL after Calling User Script is null or empty.");
             }
 
@@ -167,7 +171,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             restRequest.AddJsonBody(request.Body);
             var restResponse = client.ExecuteAsync(restRequest).Result;
 
-            context.Log.Log(LogLevel.Debug, $"{Name} - {restResponse.StatusCode} - {restResponse.Content}");
+            executionContext.Log.Log(LogLevel.Debug, $"{Name} - {restResponse.StatusCode} - {restResponse.Content}");
 
             var responseDto = new ResponseDto
             {
@@ -180,10 +184,12 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessResponseScript))
             {
                 using var engine = new Jint.Engine()
-                    .SetValue("log", new Action<object>(o => context.Log.Log(LogLevel.Information, $"User Script log: {o}" )))
+                    .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}" )))
                     .SetValue("request", request)
                     .SetValue("originalRequest", originalRequest)
                     .SetValue("response", responseDto)
+                    .SetValue("stringEncoder", stringEncoder)
+                    .SetValue("cache", cache)
                     .Execute(queryParameters.ProcessResponseScript);
 
                 var response = engine.GetValue("response").ToObject() as ResponseDto;
@@ -191,11 +197,11 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
                 if (string.IsNullOrWhiteSpace(responseDto.Content))
                 {
-                    context.Log.LogWarning($"{Name} - Response Content after Calling User Script is null or empty");
+                    executionContext.Log.LogWarning($"{Name} - Response Content after Calling User Script is null or empty");
                     throw new Exception("Response Content after Calling User Script is null or empty");
                 }
 
-                context.Log.Log(LogLevel.Debug, $"{Name} - Response after Calling User Script\n{JsonConvert.SerializeObject(response)}");
+                executionContext.Log.Log(LogLevel.Debug, $"{Name} - Response after Calling User Script\n{JsonConvert.SerializeObject(response)}");
             }
 
             if (responseDto.HttpStatus == HttpStatusCode.TooManyRequests.ToString())
@@ -263,7 +269,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             return null;
         }
 
-        public ConnectionVerificationResult VerifyConnection(ExecutionContext context, IReadOnlyDictionary<string, object> config)
+        public ConnectionVerificationResult VerifyConnection(ExecutionContext executionContext, IReadOnlyDictionary<string, object> config)
         {
             var data = new RestApiExternalSearchJobData(config.ToDictionary(x => x.Key, x => x.Value));
             var queryParametersTestConnection = new QueryParameters
@@ -308,11 +314,16 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     }
                 };
 
+                var stringEncoder = new StringEncodingHelper();
+                var cache = new Cache(executionContext);
+
                 if (!string.IsNullOrWhiteSpace(queryParametersTestConnection.ProcessRequestScript))
                 {
                     using var requestEngine = new Jint.Engine()
-                        .SetValue("log", new Action<object>(o => context.Log.Log(LogLevel.Information, $"User Script log: {o}")))
+                        .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
                         .SetValue("request", request)
+                        .SetValue("stringEncoder", stringEncoder)
+                        .SetValue("cache", cache)
                         .Execute(queryParametersTestConnection.ProcessRequestScript);
 
                     request = requestEngine.GetValue("request").ToObject() as RequestDto;
@@ -345,9 +356,11 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 if (string.IsNullOrWhiteSpace(queryParametersTestConnection.ProcessResponseScript)) return new ConnectionVerificationResult(true);
 
                 using var responseEngine = new Jint.Engine()
-                    .SetValue("log", new Action<object>(o => context.Log.Log(LogLevel.Information, $"User Script log: {o}")))
+                    .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
                     .SetValue("request", request)
                     .SetValue("response", responseDto)
+                    .SetValue("stringEncoder", stringEncoder)
+                    .SetValue("cache", cache)
                     .Execute(queryParametersTestConnection.ProcessResponseScript);
 
                 var response = responseEngine.GetValue("response").ToObject() as ResponseDto;
@@ -733,16 +746,18 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             if (query.QueryParameters.ContainsKey("processRequestScript"))
             {
-                parameters.ProcessRequestScript = query.QueryParameters.TryGetValue("processRequestScript", out var processRequestScriptValue)
-                    ? processRequestScriptValue.FirstOrDefault()
-                    : string.Empty;
+                parameters.ProcessRequestScript =
+                    query.QueryParameters.TryGetValue("processRequestScript", out var processRequestScriptValue)
+                        ? processRequestScriptValue.FirstOrDefault()
+                        : string.Empty;
             }
 
             if (query.QueryParameters.ContainsKey("processResponseScript"))
             {
-                parameters.ProcessResponseScript = query.QueryParameters.TryGetValue("processResponseScript", out var processResponseScripValue)
-                    ? processResponseScripValue.FirstOrDefault()
-                    : string.Empty;
+                parameters.ProcessResponseScript =
+                    query.QueryParameters.TryGetValue("processResponseScript", out var processResponseScripValue)
+                        ? processResponseScripValue.FirstOrDefault()
+                        : string.Empty;
             }
 
             return parameters;

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using Castle.MicroKernel.Registration;
 using CluedIn.ExternalSearch.Providers.RestApi.Helper;
 using CluedIn.ExternalSearch.Providers.RestApi.Vocabularies;
+using Jint;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -105,24 +106,17 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 ? version.FirstOrDefault()?.ToLowerInvariant()
                 : string.Empty;
 
-            switch (versionSelected)
+            return versionSelected switch
             {
                 // for backward compatibility
-                case null or "" or "v1":
-                    return ActionExtensions.ExecuteWithRetry(
-                        () => InternalExecuteSearch(context, query).ToArray(), // important we need to materialize the enumerable for ExecuteWithRetry to work
-                        retryCount: 1000,
-                        isTransient: ex => ex.ToString().Contains("TooManyRequests")
-                    );
-                case "v2":
-                    return ActionExtensions.ExecuteWithRetry(
-                        () => InternalExecuteSearchV2(context, query).ToArray(),
-                        retryCount: 1000,
-                        isTransient: ex => ex.ToString().Contains("TooManyRequests")
-                    );
-                default:
-                    throw new Exception("Unable to execute search due to invalid version.");
-            }
+                null or "" or "v1" => ActionExtensions.ExecuteWithRetry(
+                    () => InternalExecuteSearch(context, query)
+                        .ToArray(), // important we need to materialize the enumerable for ExecuteWithRetry to work
+                    retryCount: 1000, isTransient: ex => ex.ToString().Contains("TooManyRequests")),
+                "v2" => ActionExtensions.ExecuteWithRetry(() => InternalExecuteSearchV2(context, query).ToArray(),
+                    retryCount: 1000, isTransient: ex => ex.ToString().Contains("TooManyRequests")),
+                _ => throw new Exception($"Unable to execute search due to invalid version '{versionSelected}'.")
+            };
         }
 
         private IEnumerable<IExternalSearchQueryResult> InternalExecuteSearchV2(ExecutionContext executionContext,
@@ -135,23 +129,28 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessScript))
             {
-                using var engine = new Jint.Engine()
-                    .SetValue("log",
-                        new Action<object>(o =>
-                            executionContext.Log.Log(LogLevel.Information, "User Script log: {O}", o)))
+                using var engine = new Jint.Engine(options =>
+                {
+                    options
+                        .LimitRecursion(64)
+                        .MaxStatements(10_000)
+                        .TimeoutInterval(TimeSpan.FromSeconds(2));
+                });
+
+                engine
+                    .SetValue("log", new Action<object>(o =>
+                        executionContext.Log.Log(LogLevel.Information, "User Script log: {O}", o)))
                     .SetValue("stringEncoder", stringEncoder)
                     .SetValue("cache", cache)
                     .SetValue("vocabularies",
                         JsonConvert.DeserializeObject<List<PropertyDto>>(queryParameters.Body ?? string.Empty))
-                    .SetValue("http", new ScriptHttpClient())
-                    .SetValue("retry", new Action<string>(_ =>
-                    {
-                        Thread.Sleep(2000);
-                        throw new Exception("Too many requests.");
-                    })) // To have ability for retry in script
-                    .Execute(queryParameters.ProcessScript);
+                    .SetValue("http", new ScriptHttpClient());
 
-                response = engine.GetValue("response").ToObject() as string;
+                engine.Execute(queryParameters.ProcessScript);
+
+                response = engine.GetValue("response").IsUndefined()
+                    ? string.Empty
+                    : engine.GetValue("response").ToString();
             }
 
             if (string.IsNullOrWhiteSpace(response))
@@ -159,7 +158,15 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 throw new Exception("Response after Calling User Script is null.");
             }
 
-            var results = JsonConvert.DeserializeObject<ResultsDto[]>(response);
+            ResultsDto[] results;
+            try
+            {
+                results = JsonConvert.DeserializeObject<ResultsDto[]>(response);
+            }
+            catch (JsonException ex)
+            {
+                throw new Exception("Failed to deserialize user script response to ResultsDto[]. Ensure the script returns valid JSON matching the expected structure.", ex);
+            }
 
             yield return new ExternalSearchQueryResult<ResultsDto[]>(query, results);
         }
@@ -195,8 +202,16 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessRequestScript))
             {
-                using var engine = new Jint.Engine()
-                    .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
+                using var engine = new Jint.Engine(options =>
+                    {
+                        options
+                            .LimitRecursion(64)
+                            .MaxStatements(10_000)
+                            .TimeoutInterval(TimeSpan.FromSeconds(2));
+                    })
+                    .SetValue("log",
+                        new Action<object>(o =>
+                            executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
                     .SetValue("request", request)
                     .SetValue("stringEncoder", stringEncoder)
                     .SetValue("cache", cache)
@@ -239,8 +254,16 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             if (!string.IsNullOrWhiteSpace(queryParameters.ProcessResponseScript))
             {
-                using var engine = new Jint.Engine()
-                    .SetValue("log", new Action<object>(o => executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
+                using var engine = new Jint.Engine(options =>
+                    {
+                        options
+                            .LimitRecursion(64)
+                            .MaxStatements(10_000)
+                            .TimeoutInterval(TimeSpan.FromSeconds(2));
+                    })
+                    .SetValue("log",
+                        new Action<object>(o =>
+                            executionContext.Log.Log(LogLevel.Information, $"User Script log: {o}")))
                     .SetValue("request", request)
                     .SetValue("originalRequest", originalRequest)
                     .SetValue("response", responseDto)
@@ -248,7 +271,10 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     .SetValue("cache", cache)
                     .Execute(queryParameters.ProcessResponseScript);
 
-                var response = engine.GetValue("response").ToObject() as ResponseDto;
+                var response = engine.GetValue("response").IsUndefined()
+                    ? null
+                    : engine.GetValue("response").ToObject() as ResponseDto;
+
                 responseDto = response ?? throw new ApplicationException("Response after Calling User Script is null");
 
                 if (string.IsNullOrWhiteSpace(responseDto.Content))


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#55666](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/55666)

REST API enricher v2 can be enabled by choosing v2 in the `Version` control. By default v2 will be selected for newly created REST API enricher. 
<img width="1644" height="927" alt="image" src="https://github.com/user-attachments/assets/9d0ae783-6914-459e-8061-078d595826aa" />

For v2, there will be only one Process Script. (v1 has Process Request and Response Script)
<img width="1011" height="572" alt="image" src="https://github.com/user-attachments/assets/ad1f6bfc-1d55-4e70-9270-c0bbb9cfff3d" />


User can now prepare the request to make API calls through the `http.Send()` function, then process the response directly in script.  

## How has it been tested? <!-- Remove if not needed -->
Manually in local

