### PR TITLE
fix: Temporary stop throwing exception

### DIFF
--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -191,7 +191,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 if (string.IsNullOrWhiteSpace(responseDto.Content))
                 {
                     context.Log.LogWarning($"{Name} - Response Content after Calling User Script is null or empty");
-                    throw new Exception("Response Content after Calling User Script is null or empty");
+                    // Temporarily comment it out; it’s causing log overflow
+                    //throw new Exception("Response Content after Calling User Script is null or empty");
                 }
 
                 context.Log.Log(LogLevel.Debug, $"{Name} - Response after Calling User Script\n{JsonConvert.SerializeObject(response)}");

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -146,13 +146,17 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             if (request == null)
             {
-                throw new Exception("Request after Calling User Script is null.");
+                context.Log.LogWarning($"Request after Calling User Script is null");
+                // Temporarily comment the exceptions out; it’s causing log overflow
+                //throw new Exception("Request after Calling User Script is null.");
+                yield break;
             }
 
             if (string.IsNullOrWhiteSpace(request.Url))
             {
                 context.Log.LogTrace($"Skipped enrichment for record {Name} because URL is null or empty");
-                throw new Exception("URL after Calling User Script is null or empty.");
+                //throw new Exception("URL after Calling User Script is null or empty.");
+                yield break;
             }
 
             var client = new RestClient(request.Url);
@@ -186,13 +190,19 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     .Execute(queryParameters.ProcessResponseScript);
 
                 var response = engine.GetValue("response").ToObject() as ResponseDto;
-                responseDto = response ?? throw new ApplicationException("Response after Calling User Script is null");
+
+                if (response == null)
+                {
+                    yield break;
+                }
+
+                responseDto = response;
 
                 if (string.IsNullOrWhiteSpace(responseDto.Content))
                 {
                     context.Log.LogWarning($"{Name} - Response Content after Calling User Script is null or empty");
-                    // Temporarily comment it out; it’s causing log overflow
                     //throw new Exception("Response Content after Calling User Script is null or empty");
+                    yield break;
                 }
 
                 context.Log.Log(LogLevel.Debug, $"{Name} - Response after Calling User Script\n{JsonConvert.SerializeObject(response)}");


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#56125](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56125)

Temporary stop throwing exceptions to unblock blocker for Softcat. Matt and Nick mentioned that the sql storage is experiencing low storage due to large amount of enricher error logs being logged.

## How has it been tested? <!-- Remove if not needed -->
Manually in local

