### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": "false"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/packages.props
+++ b/packages.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>4.0.1</_ComponentHost>
     <_AutoFixture>5.0.0-preview0012</_AutoFixture>
     <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
@@ -11,14 +10,10 @@
     -->
 	  <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 	  <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
-	  <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-	  <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
 	  <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-	  <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
 	  <PackageReference Update="xunit.v3" Version="3.2.2" />
 	  <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
 	  <PackageReference Update="Moq" Version="4.13.1" />
-	  <PackageReference Update="Shouldly" Version="3.0.2" />
 	  <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
@@ -26,13 +21,9 @@
         Specified versions for dependencies across the solution
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="4.0.1" />
     <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="5.0.0-*" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Server" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Server.Common.WebApi" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Rules" Version="$(_CluedIn)" />
     <PackageReference Update="jint" Version="4.2.2" />

--- a/packages.props
+++ b/packages.props
@@ -1,34 +1,34 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_ComponentHost>4.0.1</_ComponentHost>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
 	  <!--
         Specified versions for dependencies in test projects
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-	  <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-	  <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
+	  <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+	  <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
 	  <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
 	  <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
 	  <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
 	  <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-	  <PackageReference Update="xunit" Version="2.4.1" />
-	  <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
+	  <PackageReference Update="xunit.v3" Version="3.2.2" />
+	  <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
 	  <PackageReference Update="Moq" Version="4.13.1" />
 	  <PackageReference Update="Shouldly" Version="3.0.2" />
-	  <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
+	  <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
         Specified versions for dependencies across the solution
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
+    <PackageReference Update="ComponentHost" Version="4.0.1" />
     <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="4.0.0" />
+    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="5.0.0-*" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Server" Version="$(_CluedIn)" />

--- a/src/ExternalSearch.Providers.RestApi.Provider/Provider.ExternalSearch.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi.Provider/Provider.ExternalSearch.RestApi.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
-    <PackageReference Include="ComponentHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
@@ -1,12 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <LangVersion>preview</LangVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <LangVersion>preview</LangVersion>
-    </PropertyGroup>
-
     <ItemGroup>
       <None Remove="Resources\RestApi.svg" />
     </ItemGroup>

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -236,7 +236,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             }
 
             var client = new RestClient(request.Url);
-            var restRequest = new RestRequest(GetHttpMethod(request.Method));
+            var restRequest = new RestRequest { Method = GetHttpMethod(request.Method) };
 
             foreach (var header in request.Headers.Where(header => !string.IsNullOrWhiteSpace(header.Key)))
             {
@@ -501,7 +501,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 }
 
                 var client = new RestClient(request.Url);
-                var restRequest = new RestRequest(GetHttpMethod(request.Method));
+                var restRequest = new RestRequest { Method = GetHttpMethod(request.Method) };
 
                 foreach (var header in request.Headers.Where(header => !string.IsNullOrWhiteSpace(header.Key) && !string.IsNullOrWhiteSpace(header.Value)))
                 {
@@ -865,8 +865,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             return methodString.ToLower() switch
             {
-                "get" => Method.GET,
-                "post" => Method.POST,
+                "get" => Method.Get,
+                "post" => Method.Post,
                 _ => throw new ArgumentException($"Unsupported HTTP method: {methodString}. Expected 'get' or 'post'.",
                     nameof(methodString))
             };

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
   </ItemGroup>

--- a/test/integration/Integration.Tests/Dummy.cs
+++ b/test/integration/Integration.Tests/Dummy.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace CluedIn.ExternalSearch.RestApi.Integration.Tests;
+
+public class Dummy
+{
+    [Fact]
+    public void ShouldPass()
+    {
+    }
+}


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`