### PR TITLE
fix: Read v2 body content type from script

### DIFF
--- a/docs/4.6.2-release-notes.md
+++ b/docs/4.6.2-release-notes.md
@@ -1,2 +1,5 @@
 ### Features
 - Implement REST API v2 with a single processing script that provides greater flexibility
+
+### Fixes
+- Read REST API v2 Http body Content-Type from script

--- a/src/ExternalSearch.Providers.RestApi/Models/ScriptHttpClient.cs
+++ b/src/ExternalSearch.Providers.RestApi/Models/ScriptHttpClient.cs
@@ -52,9 +52,18 @@ public class ScriptHttpClient
 
         using var message = new HttpRequestMessage(new HttpMethod(method), uri);
 
+        var contentType = "application/json";
         if (requestDto.Headers != null)
         {
-            foreach (var header in requestDto.Headers.Where(header => !string.IsNullOrWhiteSpace(header.Key)))
+            // Find Content-Type header if present
+            var contentTypeHeader = requestDto.Headers.FirstOrDefault(h => string.Equals(h.Key, "Content-Type", StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(contentTypeHeader?.Value))
+            {
+                contentType = contentTypeHeader.Value;
+            }
+            
+            // Add all headers except Content-Type to message.Headers
+            foreach (var header in requestDto.Headers.Where(header => !string.IsNullOrWhiteSpace(header.Key) && !string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase)))
             {
                 message.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
@@ -63,8 +72,21 @@ public class ScriptHttpClient
         if (!method.Equals(HttpMethod.Get.Method, StringComparison.OrdinalIgnoreCase)
             && requestDto.Body != null)
         {
-            var json = JsonConvert.SerializeObject(requestDto.Body);
-            message.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            string contentString;
+            if (string.Equals(contentType, "application/json", StringComparison.OrdinalIgnoreCase))
+            {
+                contentString = JsonConvert.SerializeObject(requestDto.Body);
+            }
+            else if (requestDto.Body is string strBody)
+            {
+                contentString = strBody;
+            }
+            else
+            {
+                // Fallback: serialize as JSON if not a string
+                contentString = JsonConvert.SerializeObject(requestDto.Body);
+            }
+            message.Content = new StringContent(contentString, Encoding.UTF8, contentType);
         }
 
         try
@@ -77,7 +99,7 @@ public class ScriptHttpClient
             {
                 HttpStatus = response.StatusCode.ToString(),
                 Content = content,
-                ContentType = response.Content?.Headers.ContentType?.ToString(),
+                ContentType = response.Content.Headers.ContentType?.ToString(),
                 Headers = response.Headers
                     .Select(h => new HeaderDto
                     {


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#57227](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/57227)

Shouldn't be hard coding the V2 body content-type to `application/json`, user should have ability to change the content-type from script

## How has it been tested? <!-- Remove if not needed -->
Manually in local
