### PR TITLE
feat: Create cache helper method with distributed lock

### DIFF
--- a/docs/4.6.2-release-notes.md
+++ b/docs/4.6.2-release-notes.md
@@ -1,6 +1,7 @@
 ### Features
 - Implement REST API v2 with a single processing script that provides greater flexibility
 - Added alerts for value selection and descriptions for options in the extended configuration provider
+- Create cache helper method with distributed lock
 
 ### Fixes
 - Read REST API v2 Http body Content-Type from script

--- a/packages.props
+++ b/packages.props
@@ -36,5 +36,6 @@
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Rules" Version="$(_CluedIn)" />
     <PackageReference Update="jint" Version="4.2.2" />
+    <PackageReference Update="IgnoresAccessChecksToGenerator" Version="0.8.0" />
   </ItemGroup>
 </Project>

--- a/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
@@ -1,13 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <LangVersion>preview</LangVersion>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'==''">obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
+	</PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <LangVersion>preview</LangVersion>
-    </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<LangVersion>preview</LangVersion>
+	</PropertyGroup>
 
-    <ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<LangVersion>preview</LangVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
       <None Remove="Resources\RestApi.svg" />
     </ItemGroup>
 
@@ -21,8 +26,15 @@
 		<PackageReference Include="CluedIn.Crawling" />
 		<PackageReference Include="CluedIn.Core" />
 		<PackageReference Include="CluedIn.Rules" />
+		<PackageReference Include="IgnoresAccessChecksToGenerator">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<InternalsVisibleTo Include="CluedIn.Provider.ExternalSearch.RestApi" />
+	</ItemGroup>
+	<ItemGroup>
+		<IgnoresAccessChecksTo Include="CluedIn.Core" />
 	</ItemGroup>
 </Project>

--- a/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
 		<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'==''">obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
 	</PropertyGroup>
 

--- a/src/ExternalSearch.Providers.RestApi/Helper/Cache.cs
+++ b/src/ExternalSearch.Providers.RestApi/Helper/Cache.cs
@@ -1,4 +1,6 @@
+using CluedIn.Core.Threading;
 using System;
+using Microsoft.Extensions.Logging;
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 
 namespace CluedIn.ExternalSearch.Providers.RestApi.Helper;
@@ -29,5 +31,56 @@ public class Cache(ExecutionContext executionContext)
         }
 
         executionContext.ApplicationContext.System.Cache.SetItem(keyWithOrgId, value, expiration > 0 ? DateTimeOffset.Now.AddMilliseconds(expiration) : null);
+    }
+
+    public object GetOrSetValue(string key, object value, double expiration)
+    {
+        return GetOrSetInternal(key, () => value, expiration);
+    }
+
+    public object GetOrSetFactory(string key, Func<object> factory, double expiration)
+    {
+        return GetOrSetInternal(key, factory, expiration);
+    }
+
+    private object GetOrSetInternal(
+        string key,
+        Func<object> factory,
+        double expiration)
+    {
+        if (factory == null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        var cached = Get(key);
+        if (cached != null)
+        {
+            return cached;
+        }
+
+        var keyWithOrgId = $"{executionContext.Organization.Id}_{key}";
+        try
+        {
+            using var scope = executionContext.ApplicationContext.System.Locks.CreateLockingScope();
+            using var applicationLock = scope.GetClusterWideExclusiveLock($"RestApiEnricher_Cache_Lock_{keyWithOrgId}", TimeSpan.FromSeconds(30));
+
+            cached = Get(key);
+            if (cached != null)
+            {
+                return cached;
+            }
+
+            var value = factory();
+
+            Set(key, value, expiration);
+
+            return value;
+        }
+        catch (ApplicationLockProviderException ex)
+        {
+            executionContext.Log.LogWarning(ex, "[Enricher] Lock Exception Getting REST API enricher cache {Key}", key);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#57516](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/57516)

With this Process Script
```Javascript
const random = Math.random();
log(JSON.stringify(random));
const token = cache.GetOrSetValue("test_token_new", "123abc" + random, 3000000);
log(JSON.stringify(token));
```

The value being used is the one that cached instead of calling a new cache
<img width="801" height="362" alt="image" src="https://github.com/user-attachments/assets/6a6da285-41c8-4cc5-8419-10b0b4d81be7" />


Another way of getting or caching the token
```Javascript
    const token = cache.GetOrSetFactory("dnb_auth_token", () => {
    const tokenResponse = http.Send({
          url: `https://plus.dnb.com/v2/token`,
          method: "POST",
          headers: [              
              {Key: 'Content-Type', Value: 'application/json'},
              {Key: 'Authorization', Value: `Basic ${base64}`}
              ],
          body: { grant_type: 'client_credentials' }
        });

      return JSON.parse(tokenResponse.Content).access_token;
    }, 3000000);
```



## How has it been tested? <!-- Remove if not needed -->
Manually in local

