### PR TITLE
Migrate to multi-version connector packaging (Option B)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,20 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net10.0</TargetFramework>
+    <!--
+        CluedInMultiVersionTargetFramework, not a direct -p:TargetFramework= override, so that
+        multi-version builds against older CluedIn.Core releases (which need an older framework -
+        see azure-pipelines.yml) work across ProjectReferences between projects in this repo.
+        MSBuild's ProjectReference protocol undefines the reserved TargetFramework global property
+        when it re-evaluates a referenced project, so a raw -p:TargetFramework= override on the
+        outer project never reaches an inner ProjectReference - a plain project-evaluated property
+        like this one isn't subject to that and propagates normally.
+    -->
+    <TargetFramework Condition="'$(CluedInMultiVersionTargetFramework)' != ''">$(CluedInMultiVersionTargetFramework)</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net10.0</TargetFramework>
+    <!-- Matches this repo's own normal (net10.0) LangVersion even when TargetFramework is forced
+         older for a multi-version build - net6.0's own default LangVersion (10) doesn't support
+         syntax already used in this codebase (raw string literals, primary constructors). -->
+    <LangVersion Condition="'$(LangVersion)' == ''">latest</LangVersion>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ parameters:
   - name: pipelineTemplateRef
     displayName: Pipeline Template Ref
     type: string
-    default: refs/heads/feature/option-b-multi-version-packaging
+    default: refs/heads/feature/multi-version-packaging
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,4 +66,4 @@ steps:
       # CluedIn.Mcp, this repo has two packable projects under src/, so it exercises auto-discovery
       # of packable projects instead of the single-project case.
       multiVersionCluedInTargets:
-        - cluedInVersion: '5.0.0'
+        - cluedInVersion: '4.8.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,9 @@ steps:
       publishToDevFeed: true
       # Test consumer for the generalized (N-project) multi-version packaging design: unlike
       # CluedIn.Mcp, this repo has two packable projects under src/, so it exercises auto-discovery
-      # of packable projects instead of the single-project case.
+      # of packable projects instead of the single-project case. targetFramework is required here -
+      # this repo's own Directory.Build.props defaults to net10.0 (matching the develop/5.0.0 line
+      # it normally builds against), but CluedIn.Core 4.8.0 was published for net6.0.
       multiVersionCluedInTargets:
         - cluedInVersion: '4.8.0'
+          targetFramework: 'net6.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,11 +51,16 @@ jobs:
       # Test consumer for the generalized (N-project) multi-version packaging design: unlike
       # CluedIn.Mcp, this repo has two packable projects under src/, so it exercises auto-discovery
       # of packable projects instead of the single-project case. targetFramework is required for
-      # 4.8.0 - this repo's own Directory.Build.props defaults to net10.0 (matching the develop/5.0.0
-      # line it normally builds against), but CluedIn.Core 4.8.0 was published for net6.0.
+      # 4.x - this repo's own Directory.Build.props defaults to net10.0 (matching the develop/5.0.0
+      # line it normally builds against), but CluedIn.Core 4.x was published for net6.0.
       # 5.0.0-alpha.* tests the floating/prerelease cluedInVersion support - 5.0.0 itself hasn't
       # released yet, only prerelease builds exist in the develop feed.
+      # 4.6.0 - the oldest real released version in the 4.6.x line (there's no 4.6.2 package; only
+      # a release/4.6.0 git branch exists) - is a third, older target to further prove out the
+      # generalized N-target design.
       multiVersionCluedInTargets:
+        - cluedInVersion: '4.6.0'
+          targetFramework: 'net6.0'
         - cluedInVersion: '4.8.0'
           targetFramework: 'net6.0'
         - cluedInVersion: '5.0.0-alpha.*'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ parameters:
   - name: pipelineTemplateRef
     displayName: Pipeline Template Ref
     type: string
-    default: refs/heads/refactor
+    default: refs/heads/feature/option-b-multi-version-packaging
 
 trigger:
   branches:
@@ -62,3 +62,8 @@ steps:
       publishCodeCoverage: true
       useGitVersionDotNetTool: true
       publishToDevFeed: true
+      # Test consumer for the generalized (N-project) multi-version packaging design: unlike
+      # CluedIn.Mcp, this repo has two packable projects under src/, so it exercises auto-discovery
+      # of packable projects instead of the single-project case.
+      multiVersionCluedInTargets:
+        - cluedInVersion: '5.0.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,5 @@
 name: $(Date:yyyyMMdd)$(Rev:.r)
 parameters:
-  - name: runIntegrationTests
-    displayName: Run Integration Tests
-    type: boolean
-    default: false
-
   - name: pipelineTemplateRef
     displayName: Pipeline Template Ref
     type: string
@@ -28,9 +23,6 @@ resources:
       endpoint: "CluedIn-io"
       ref: ${{ parameters.pipelineTemplateRef }}
 
-pool:
-  vmImage: "windows-latest"
-
 variables:
   - name: testFolderPath
     value: "$(Build.SourcesDirectory)/test"
@@ -41,24 +33,18 @@ variables:
   - name: buildConfiguration
     value: Release
 
-steps:
-  - task: UseDotNet@2
-    displayName: Install .NET SDK 8.0
-    inputs:
-        version: 8.0.x
-
-  - task: NuGetAuthenticate@0
-    displayName: "Authenticate with nuget"
-
-  - template: crawler.build.yml@templates
+# jobs:, not pool:/steps: - crawler.build.jobs.yml (unlike crawler.build.yml) is a jobs template:
+# it builds and tests each multiVersionCluedInTargets entry in its own parallel job instead of
+# sequential steps in one job, so UseDotNet@2/NuGetAuthenticate@0 now live inside the template
+# itself (every job needs its own copy - jobs are isolated agents) rather than being set up once
+# here. Integration tests aren't supported by this template yet.
+jobs:
+  - template: crawler.build.jobs.yml@templates
     parameters:
+      pool:
+        vmImage: "windows-latest"
       githubReleaseInMaster: true
       publicReleaseForMaster: true
-      executeIntegrationTests: ${{ parameters.runIntegrationTests }}
-      createIntegrationEnvironmentScriptFilePath: "./build/integration-test.ps1"
-      createIntegrationEnvironmentScriptArguments: "-Action SetUp"
-      deleteIntegrationEnvironmentScriptFilePath: "./build/integration-test.ps1"
-      deleteIntegrationEnvironmentScriptArguments: "-Action TearDown"
       publishCodeCoverage: true
       useGitVersionDotNetTool: true
       publishToDevFeed: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,9 +64,13 @@ steps:
       publishToDevFeed: true
       # Test consumer for the generalized (N-project) multi-version packaging design: unlike
       # CluedIn.Mcp, this repo has two packable projects under src/, so it exercises auto-discovery
-      # of packable projects instead of the single-project case. targetFramework is required here -
-      # this repo's own Directory.Build.props defaults to net10.0 (matching the develop/5.0.0 line
-      # it normally builds against), but CluedIn.Core 4.8.0 was published for net6.0.
+      # of packable projects instead of the single-project case. targetFramework is required for
+      # 4.8.0 - this repo's own Directory.Build.props defaults to net10.0 (matching the develop/5.0.0
+      # line it normally builds against), but CluedIn.Core 4.8.0 was published for net6.0.
+      # 5.0.0-alpha.* tests the floating/prerelease cluedInVersion support - 5.0.0 itself hasn't
+      # released yet, only prerelease builds exist in the develop feed.
       multiVersionCluedInTargets:
         - cluedInVersion: '4.8.0'
           targetFramework: 'net6.0'
+        - cluedInVersion: '5.0.0-alpha.*'
+          targetFramework: 'net10.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,16 +48,12 @@ jobs:
       publishCodeCoverage: true
       useGitVersionDotNetTool: true
       publishToDevFeed: true
-      # Test consumer for the generalized (N-project) multi-version packaging design: unlike
-      # CluedIn.Mcp, this repo has two packable projects under src/, so it exercises auto-discovery
-      # of packable projects instead of the single-project case. targetFramework is required for
-      # 4.x - this repo's own Directory.Build.props defaults to net10.0 (matching the develop/5.0.0
-      # line it normally builds against), but CluedIn.Core 4.x was published for net6.0.
-      # 5.0.0-alpha.* tests the floating/prerelease cluedInVersion support - 5.0.0 itself hasn't
-      # released yet, only prerelease builds exist in the develop feed.
-      # 4.6.0 - the oldest real released version in the 4.6.x line (there's no 4.6.2 package; only
-      # a release/4.6.0 git branch exists) - is a third, older target to further prove out the
-      # generalized N-target design.
+      # targetFramework is required for the 4.x line - this repo's own Directory.Build.props
+      # defaults to net10.0 (matching the develop/5.0.0 line it normally builds against), but
+      # CluedIn.Core 4.x was published for net6.0. 5.0.0-alpha.* is a floating/prerelease
+      # cluedInVersion: 5.0.0 itself hasn't released yet, only prerelease builds exist in the
+      # develop feed. 4.6.0 is the oldest real released version in the 4.6.x line (there is no
+      # 4.6.2 package; only a release/4.6.0 git branch exists).
       multiVersionCluedInTargets:
         - cluedInVersion: '4.6.0'
           targetFramework: 'net6.0'

--- a/packages.props
+++ b/packages.props
@@ -41,5 +41,13 @@
   <ItemGroup Condition="$(_CluedIn.StartsWith('4.'))">
     <PackageReference Update="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageReference Update="System.Runtime.Caching" Version="8.0.0" />
+    <!--
+        RestSharp is a transitive dependency (pulled in via CluedIn.Core, never referenced directly
+        here) whose Method enum was renamed from GET/POST to Get/Post in v107 - the code already uses
+        the newer Get/Post names, but CluedIn.Core 4.x's own dependency graph pulls a pre-v107
+        RestSharp. Pinning it directly to a v107+ version, same remedy as above, keeps the existing
+        source code compiling unchanged.
+    -->
+    <PackageReference Update="RestSharp" Version="114.0.0" />
   </ItemGroup>
 </Project>

--- a/packages.props
+++ b/packages.props
@@ -42,11 +42,11 @@
     <PackageReference Update="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageReference Update="System.Runtime.Caching" Version="8.0.0" />
     <!--
-        RestSharp is a transitive dependency (pulled in via CluedIn.Core, never referenced directly
-        here) whose Method enum was renamed from GET/POST to Get/Post in v107 - the code already uses
-        the newer Get/Post names, but CluedIn.Core 4.x's own dependency graph pulls a pre-v107
-        RestSharp. Pinning it directly to a v107+ version, same remedy as above, keeps the existing
-        source code compiling unchanged.
+        RestSharp is pulled in transitively via CluedIn.Core; its Method enum was renamed from
+        GET/POST to Get/Post in v107 - the code already uses the newer Get/Post names, but
+        CluedIn.Core 4.x's own dependency graph pulls a pre-v107 RestSharp. Pinning it directly to
+        a v107+ version here, same remedy as above, keeps the existing source code compiling
+        unchanged.
     -->
     <PackageReference Update="RestSharp" Version="114.0.0" />
   </ItemGroup>

--- a/packages.props
+++ b/packages.props
@@ -29,4 +29,17 @@
     <PackageReference Update="jint" Version="4.2.2" />
     <PackageReference Update="IgnoresAccessChecksToGenerator" Version="0.8.0" />
   </ItemGroup>
+  <!--
+      CluedIn.Core 4.x's published dependency graph declares System.Configuration.ConfigurationManager
+      and System.Runtime.Caching at two different minimum versions - a direct >= 6.x dependency
+      alongside a transitive >= 8.0.0 one via Microsoft.Data.SqlClient 5.2.2 - which NuGet reports as
+      a downgrade error regardless of this project's own target framework. Referencing them directly
+      at the higher version, exactly what the NU1605 error itself recommends, resolves it. Only
+      needed for 4.x targets (see the matching PackageReference Include in each affected .csproj) -
+      CluedIn.Core 5.x doesn't have this inconsistency.
+  -->
+  <ItemGroup Condition="$(_CluedIn.StartsWith('4.'))">
+    <PackageReference Update="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Update="System.Runtime.Caching" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/ExternalSearch.Providers.RestApi.Provider/Provider.ExternalSearch.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi.Provider/Provider.ExternalSearch.RestApi.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
 	<ProjectReference Include="..\ExternalSearch.Providers.RestApi\ExternalSearch.Providers.RestApi.csproj" />
   </ItemGroup>
-  <!-- Version pinned centrally in Packages.props, conditional on _CluedIn - see comment there. -->
+  <!-- Version pinned centrally in packages.props, conditional on _CluedIn - see comment there. -->
   <ItemGroup Condition="$(_CluedIn.StartsWith('4.'))">
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Runtime.Caching" />

--- a/src/ExternalSearch.Providers.RestApi.Provider/Provider.ExternalSearch.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi.Provider/Provider.ExternalSearch.RestApi.csproj
@@ -13,4 +13,9 @@
   <ItemGroup>
 	<ProjectReference Include="..\ExternalSearch.Providers.RestApi\ExternalSearch.Providers.RestApi.csproj" />
   </ItemGroup>
+  <!-- Version pinned centrally in Packages.props, conditional on _CluedIn - see comment there. -->
+  <ItemGroup Condition="$(_CluedIn.StartsWith('4.'))">
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
+    <PackageReference Include="System.Runtime.Caching" />
+  </ItemGroup>
 </Project>

--- a/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<IgnoresAccessChecksTo Include="CluedIn.Core" />
 	</ItemGroup>
-	<!-- Version pinned centrally in Packages.props, conditional on _CluedIn - see comment there. -->
+	<!-- Version pinned centrally in packages.props, conditional on _CluedIn - see comment there. -->
 	<ItemGroup Condition="$(_CluedIn.StartsWith('4.'))">
 		<PackageReference Include="System.Configuration.ConfigurationManager" />
 		<PackageReference Include="System.Runtime.Caching" />

--- a/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
@@ -24,4 +24,9 @@
 	<ItemGroup>
 		<IgnoresAccessChecksTo Include="CluedIn.Core" />
 	</ItemGroup>
+	<!-- Version pinned centrally in Packages.props, conditional on _CluedIn - see comment there. -->
+	<ItemGroup Condition="$(_CluedIn.StartsWith('4.'))">
+		<PackageReference Include="System.Configuration.ConfigurationManager" />
+		<PackageReference Include="System.Runtime.Caching" />
+	</ItemGroup>
 </Project>

--- a/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
+++ b/src/ExternalSearch.Providers.RestApi/ExternalSearch.Providers.RestApi.csproj
@@ -28,5 +28,6 @@
 	<ItemGroup Condition="$(_CluedIn.StartsWith('4.'))">
 		<PackageReference Include="System.Configuration.ConfigurationManager" />
 		<PackageReference Include="System.Runtime.Caching" />
+		<PackageReference Include="RestSharp" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
Moves this repo onto CluedIn-io/AzurePipelines.Templates' \`crawler.build.jobs.yml\` (Option B): a single branch, with CI building one variant per supported CluedIn version in parallel and bundling them into one NuGet package with a build-time switch.

Targets 4.6.0, 4.8.0 and 5.0.0-alpha.*. This repo has two packable projects under \`src/\`, one referencing the other via a plain \`ProjectReference\` - which is why \`Directory.Build.props\` reads a custom \`CluedInMultiVersionTargetFramework\` property rather than relying on a raw \`-p:TargetFramework=\` override: \`ProjectReference\` undefines the reserved \`TargetFramework\` global property on re-evaluation, so a raw override on the outer project never reached the inner one (confirmed in practice on this exact repo).

Work Item ID: [AB#57964](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/57964)


## How has it been tested?
CI builds, unit-tests, packs and verifies cleanly against all three targets, confirming \`CluedInMultiVersionTargetFramework\` correctly propagates to both packable projects.

## Release Note
Connector builds for CluedIn 4.6, 4.8 and 5.0 now ship from a single published package instead of separately versioned per-line packages.