### PR TITLE
feat: Ability to return multiple results

### DIFF
--- a/docs/5.0.0-release-notes.md
+++ b/docs/5.0.0-release-notes.md
@@ -1,0 +1,2 @@
+### Features
+- Allow REST API enricher to return multiple results

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -173,7 +173,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 yield break;
             }
 
-            yield return new ExternalSearchQueryResult<ResultsDto[]>(query, results);
+            foreach (var result in results)
+                yield return new ExternalSearchQueryResult<ResultsDto[]>(query, [result]);
         }
 
         private IEnumerable<IExternalSearchQueryResult> InternalExecuteSearch(ExecutionContext executionContext, IExternalSearchQuery query)
@@ -316,7 +317,8 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
 
             var results = JsonConvert.DeserializeObject<ResultsDto[]>(responseDto.Content);
 
-            yield return new ExternalSearchQueryResult<ResultsDto[]>(query, results);
+            foreach (var result in results)
+                yield return new ExternalSearchQueryResult<ResultsDto[]>(query, [result]);
         }
 
         public IEnumerable<Clue> BuildClues(ExecutionContext context, IExternalSearchQuery query, IExternalSearchQueryResult result, IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#58189](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/58189)

REST API enricher is now having the ability to return multiple results as in screenshot
<img width="1010" height="706" alt="image" src="https://github.com/user-attachments/assets/b1484486-cf49-4bbc-af28-520bca1878f9" />

<img width="1681" height="501" alt="image" src="https://github.com/user-attachments/assets/2c46764d-d571-41c2-b79f-ed70dc22dc68" />

Script
```javascript
let results1 = {
    "restapi.companyName": "PFIZER LIMITED",
    "restapi.companyHouseNumber": 00526209,
};

let results2 = {
    "restapi.companyName": "PFIZER",
    "restapi.companyHouseNumber": 526209,
};

let results3 = {
    "restapi.companyName": "PFIZER NEW",
    "restapi.companyHouseNumber": 123456,
};
response = JSON.stringify([{
    Data: results1,
    Score: 100
}, {
    Data: results2,
    Score: 80
}, {
    Data: results3,
    Score: 20
}]);
```

## How has it been tested? <!-- Remove if not needed -->
Manually in local

