### PR TITLE
fix: Increase jint timeout interval

### DIFF
--- a/docs/4.6.3-release-notes.md
+++ b/docs/4.6.3-release-notes.md
@@ -1,0 +1,2 @@
+### Fixes
+- Increase Jint timeout interval to avoid operation timeout exception

--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -135,7 +135,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                     options
                         .LimitRecursion(64)
                         .MaxStatements(10_000)
-                        .TimeoutInterval(TimeSpan.FromSeconds(2));
+                        .TimeoutInterval(TimeSpan.FromSeconds(120));
                 });
 
                 engine
@@ -213,7 +213,7 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                         options
                             .LimitRecursion(64)
                             .MaxStatements(10_000)
-                            .TimeoutInterval(TimeSpan.FromSeconds(2));
+                            .TimeoutInterval(TimeSpan.FromSeconds(120));
                     })
                     .SetValue("log",
                         new Action<object>(o =>


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#58226](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/58226)

Increasing the Jint timeout interval to 120 seconds and now able to enrich with API that taking a bit longer time to process

## How has it been tested? <!-- Remove if not needed -->
Manually in local

