### PR TITLE
chore: Add extra null check on execute search result

### DIFF
--- a/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.RestApi/RestApiExternalSearchProvider.cs
@@ -173,6 +173,9 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
                 yield break;
             }
 
+            if (results == null)
+                yield break;
+
             foreach (var result in results)
                 yield return new ExternalSearchQueryResult<ResultsDto[]>(query, [result]);
         }
@@ -316,6 +319,9 @@ namespace CluedIn.ExternalSearch.Providers.RestApi
             if (responseDto.HttpStatus != nameof(HttpStatusCode.OK)) throw new ApplicationException($"Call returned HTTP {responseDto.HttpStatus} - {responseDto.Content}");
 
             var results = JsonConvert.DeserializeObject<ResultsDto[]>(responseDto.Content);
+
+            if (results == null)
+                yield break;
 
             foreach (var result in results)
                 yield return new ExternalSearchQueryResult<ResultsDto[]>(query, [result]);


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description

Add extra null check on ExecuteSearch() results to prevent passing null result to PopulateMetadata() later

## How has it been tested? <!-- Remove if not needed -->
Manually in local


